### PR TITLE
fix(usuário): feito ajuste em validação de envio de parâmetro para rota de criação de usuário na aplicação - VLT-170 (#31)

### DIFF
--- a/components/organisms/Forms/User/ZUserForm.vue
+++ b/components/organisms/Forms/User/ZUserForm.vue
@@ -225,7 +225,10 @@ export default {
       }
     },
     data(val) {
-      this.form = { ...val, birthDate: val.information.birthDate };
+      if (val.information) {
+        val.birthDate = val.information.birthDate ?? null;
+      }
+      this.form = { ...val };
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",

--- a/pages/players/create/index.vue
+++ b/pages/players/create/index.vue
@@ -66,6 +66,11 @@ export default {
           teamId: form.teams.map((item) => item.id),
         };
 
+        // NOTE - se o password for vazio, não enviar
+        if (variables.password === "") {
+          delete variables.password;
+        }
+
         const { mutate } = await useMutation(query, { variables });
 
         const { data } = await mutate();


### PR DESCRIPTION
…

### O que?

Feito validação para não enviar o parâmetro de senha de usuário já que o campo não aparece em tela.

### Por quê?

O usuário não estava conseguindo seguir com o cadastro dos usuários no sistema.


### Capturas de tela
Este é o erro relatado pelo cliente:
![image](https://github.com/Zoren-Software/VolleyTrack-Front/assets/25940408/8855460f-e0d8-4b47-ae86-0bb63675dc4d)


### Verificações
- [x] Lembrete: Ajustar o `composer.json` com a versão.

