### PR TITLE
feat(configuração de notificações): adicionando modal de configuração de notificações - VT-14

### DIFF
--- a/components/atoms/Modal/ZModal.vue
+++ b/components/atoms/Modal/ZModal.vue
@@ -1,0 +1,38 @@
+<template>
+  <VaModal
+    :model-value="modelValue"
+    @update:modelValue="$emit('update:modelValue', $event)"
+    :title="title"
+    size="medium"
+    close-button
+    class="z-modal"
+  >
+    <slot />
+    <template #footer v-if="$slots.footer">
+      <slot name="footer" />
+    </template>
+  </VaModal>
+</template>
+
+<script>
+export default {
+  name: "ZModal",
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+    title: {
+      type: String,
+      default: "",
+    },
+  },
+  emits: ["update:modelValue"],
+};
+</script>
+
+<style scoped>
+.z-modal {
+  max-width: 600px;
+}
+</style>

--- a/components/atoms/Modal/ZModal.vue
+++ b/components/atoms/Modal/ZModal.vue
@@ -1,13 +1,20 @@
 <template>
   <VaModal
+    v-bind="$attrs"
     :model-value="modelValue"
     @update:modelValue="$emit('update:modelValue', $event)"
-    :title="title"
     size="medium"
     close-button
     class="z-modal"
   >
+    <template #header>
+      <h5 class="font-bold text-lg va-h5">
+        {{ title }}
+      </h5>
+    </template>
+
     <slot />
+
     <template #footer v-if="$slots.footer">
       <slot name="footer" />
     </template>
@@ -28,6 +35,7 @@ export default {
     },
   },
   emits: ["update:modelValue"],
+  inheritAttrs: false, // 🔥 necessário para evitar duplicação com `v-bind="$attrs"`
 };
 </script>
 

--- a/components/molecules/Modal/ZFormModal.vue
+++ b/components/molecules/Modal/ZFormModal.vue
@@ -5,6 +5,7 @@
     :title="title"
     ok-text="Salvar"
     cancel-text="Cancelar"
+    @ok="$emit('submit')"
   >
     <template #default>
       <form @submit.prevent="$emit('submit')">

--- a/components/molecules/Modal/ZFormModal.vue
+++ b/components/molecules/Modal/ZFormModal.vue
@@ -1,0 +1,35 @@
+<template>
+  <ZModal
+    :model-value="modelValue"
+    @update:modelValue="$emit('update:modelValue', $event)"
+    :title="title"
+    ok-text="Salvar"
+    cancel-text="Cancelar"
+  >
+    <template #default>
+      <form @submit.prevent="$emit('submit')">
+        <slot />
+      </form>
+    </template>
+  </ZModal>
+</template>
+
+<script>
+import ZModal from "~/components/atoms/Modal/ZModal.vue";
+
+export default {
+  name: "ZFormModal",
+  components: { ZModal },
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+    title: {
+      type: String,
+      default: "Formulário",
+    },
+  },
+  emits: ["update:modelValue", "submit"],
+};
+</script>

--- a/components/molecules/NavBar/ZNavBarItemLogo.vue
+++ b/components/molecules/NavBar/ZNavBarItemLogo.vue
@@ -3,31 +3,30 @@
     <ZIcon
       class="ml-2"
       :name="minimized ? `menu` : `menu_open`"
-      @click="toggleMinimize"
+      @click="toggleMinimize()"
     />
   </ZNavBarItem>
 </template>
 
 <script>
-
-import ZIcon from '~/components/atoms/Icons/ZIcon';
-import ZNavBarItem from '~/components/atoms/NavBar/ZNavBarItem';
+import ZIcon from "~/components/atoms/Icons/ZIcon";
+import ZNavBarItem from "~/components/atoms/NavBar/ZNavBarItem";
 
 export default {
   components: { ZNavBarItem, ZIcon },
   props: {
     minimized: {
       type: Boolean,
-      default: false
+      default: false,
     },
   },
   emits: ["toggleMinimize"],
   methods: {
     toggleMinimize() {
       this.$emit("toggleMinimize");
-    }
+    },
   },
-}
+};
 </script>
 
 <style scoped>

--- a/components/molecules/NavBar/ZNavBarItemSettings.vue
+++ b/components/molecules/NavBar/ZNavBarItemSettings.vue
@@ -1,11 +1,12 @@
 <template>
-  <ZButton :color="color()" icon="settings" to="/settings" />
+  <ZButton :color="color()" icon="settings" @click="toggleSidebar()" />
 </template>
 
 <script>
 import ZButton from "~/components/atoms/Buttons/ZButton";
 
 export default {
+  emits: ["menuSettingsMinimize"],
   components: {
     ZButton,
   },
@@ -14,6 +15,9 @@ export default {
       return this.$route.path === "/settings"
         ? "primary"
         : "background-primary";
+    },
+    toggleSidebar() {
+      this.$emit("menuSettingsMinimize");
     },
   },
 };

--- a/components/molecules/Sidebar/ZSidebarSettings.vue
+++ b/components/molecules/Sidebar/ZSidebarSettings.vue
@@ -1,0 +1,73 @@
+<template>
+  <VaSidebar
+    :model-value="modelValue"
+    @update:modelValue="(val) => $emit('update:modelValue', val)"
+    class="settings-sidebar"
+    animated="right"
+  >
+    <VaSidebarItem
+      v-for="item in menuSettings"
+      :key="item.title"
+      :active="item.active"
+    >
+      <VaSidebarItemContent
+        @click="handleMenuItemClick(item)"
+        style="cursor: pointer"
+      >
+        <VaIcon :name="item.icon" />
+        <VaSidebarItemTitle>
+          {{ item.title }}
+        </VaSidebarItemTitle>
+      </VaSidebarItemContent>
+    </VaSidebarItem>
+  </VaSidebar>
+</template>
+
+<script>
+export default {
+  name: "ZSidebarSettings",
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  emits: ["update:modelValue"],
+  data() {
+    return {
+      menuSettings: [
+        {
+          title: "Configurações da Conta",
+          icon: "settings",
+          to: "/settings",
+          active: false,
+        },
+        {
+          title: "Configurações de Notificação",
+          icon: "notifications",
+          to: "/notifications",
+          active: false,
+        },
+        {
+          title: "Fechar Configurações",
+          icon: "close",
+          action: () => {
+            this.enabledSettings = false;
+          },
+        },
+      ],
+    };
+  },
+  methods: {
+    handleMenuItemClick(item) {
+      if (item.action) {
+        item.action.call(this);
+        this.$emit("update:modelValue", false);
+      } else if (item.to) {
+        this.$router.push(item.to);
+        this.$emit("update:modelValue", false);
+      }
+    },
+  },
+};
+</script>

--- a/components/molecules/Sidebar/ZSidebarSettings.vue
+++ b/components/molecules/Sidebar/ZSidebarSettings.vue
@@ -1,7 +1,7 @@
 <template>
   <VaSidebar
     :model-value="modelValue"
-    @update:modelValue="(val) => $emit('update:modelValue', val)"
+    @update:modelValue="$emit('update:modelValue', $event)"
     class="settings-sidebar"
     animated="right"
   >
@@ -20,12 +20,18 @@
         </VaSidebarItemTitle>
       </VaSidebarItemContent>
     </VaSidebarItem>
+    <ZNotificationSettingsForm v-model="openNotificationModal" />
   </VaSidebar>
 </template>
 
 <script>
+import ZNotificationSettingsForm from "~/components/organisms/Settings/ZNotificationSettingsForm.vue";
+
 export default {
   name: "ZSidebarSettings",
+  components: {
+    ZNotificationSettingsForm,
+  },
   props: {
     modelValue: {
       type: Boolean,
@@ -35,6 +41,7 @@ export default {
   emits: ["update:modelValue"],
   data() {
     return {
+      openNotificationModal: false,
       menuSettings: [
         {
           title: "Configurações da Conta",
@@ -45,14 +52,16 @@ export default {
         {
           title: "Configurações de Notificação",
           icon: "notifications",
-          to: "/notifications",
           active: false,
+          action: () => {
+            this.openNotificationModal = true;
+          },
         },
         {
           title: "Fechar Configurações",
           icon: "close",
           action: () => {
-            this.enabledSettings = false;
+            this.$emit("update:modelValue", false);
           },
         },
       ],
@@ -62,7 +71,6 @@ export default {
     handleMenuItemClick(item) {
       if (item.action) {
         item.action.call(this);
-        this.$emit("update:modelValue", false);
       } else if (item.to) {
         this.$router.push(item.to);
         this.$emit("update:modelValue", false);

--- a/components/organisms/NavBar/ZNavBar.vue
+++ b/components/organisms/NavBar/ZNavBar.vue
@@ -41,13 +41,6 @@ export default {
     ZNavBarItemSettings,
   },
 
-  props: {
-    menuSettings: {
-      type: Array,
-      required: true,
-    },
-  },
-
   emits: ["menuSettingsMinimize"],
 
   data() {

--- a/components/organisms/NavBar/ZNavBar.vue
+++ b/components/organisms/NavBar/ZNavBar.vue
@@ -15,7 +15,7 @@
       <!-- <ZNavBarItemReport /> -->
       <ZNavBarItemNotification />
       <ZNavBarItemUser :user="user" :firstLatter="firstLatter" />
-      <ZNavBarItemSettings />
+      <ZNavBarItemSettings @menu-settings-minimize="onMenuSettingsMinimize" />
     </template>
   </va-navbar>
 </template>
@@ -41,7 +41,14 @@ export default {
     ZNavBarItemSettings,
   },
 
-  emits: ["toggleMinimize"],
+  props: {
+    menuSettings: {
+      type: Array,
+      required: true,
+    },
+  },
+
+  emits: ["menuSettingsMinimize"],
 
   data() {
     return {
@@ -142,9 +149,17 @@ export default {
   },
 
   methods: {
-    toggleMinimize() {
-      this.minimized = !this.minimized;
-      this.$emit("toggleMinimize", this.minimized);
+    onMenuSettingsMinimize(value) {
+      this.minimized = value;
+      console.log("emit 2");
+      this.$emit("menuSettingsMinimize", this.minimized);
+    },
+    toggleMinimize(value) {
+      this.$emit("toggleMinimize", value);
+    },
+    onMenuSettingsMinimize(value) {
+      this.minimized = value;
+      this.$emit("menuSettingsMinimize", this.minimized);
     },
 
     async getUser() {

--- a/components/organisms/Settings/ZNotificationSettingsForm.vue
+++ b/components/organisms/Settings/ZNotificationSettingsForm.vue
@@ -103,8 +103,6 @@ export default {
 
     async salvarConfiguracoes() {
       try {
-        console.log("Salvar configurações de notificação:", this.form);
-
         this.loading = true;
         this.errorFields = [];
         this.errors = {};

--- a/components/organisms/Settings/ZNotificationSettingsForm.vue
+++ b/components/organisms/Settings/ZNotificationSettingsForm.vue
@@ -1,0 +1,50 @@
+<template>
+  <ZFormModal
+    v-model="open"
+    title="Configurações de Notificação"
+    @submit="salvarConfiguracoes"
+  >
+    <VaCheckbox v-model="form.viaEmail" label="Receber por e-mail" />
+    <VaCheckbox v-model="form.viaSystem" label="Receber no sistema" />
+  </ZFormModal>
+</template>
+
+<script>
+import ZFormModal from "~/components/molecules/Modal/ZFormModal.vue";
+
+export default {
+  name: "ZNotificationSettingsForm",
+  components: { ZFormModal },
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  emits: ["update:modelValue"],
+  data() {
+    return {
+      form: {
+        viaEmail: true,
+        viaSystem: true,
+      },
+    };
+  },
+  computed: {
+    open: {
+      get() {
+        return this.modelValue;
+      },
+      set(val) {
+        this.$emit("update:modelValue", val);
+      },
+    },
+  },
+  methods: {
+    salvarConfiguracoes() {
+      console.log("Salvar configurações de notificação:", this.form);
+      this.$emit("update:modelValue", false);
+    },
+  },
+};
+</script>

--- a/components/organisms/Settings/ZNotificationSettingsForm.vue
+++ b/components/organisms/Settings/ZNotificationSettingsForm.vue
@@ -4,13 +4,39 @@
     title="Configurações de Notificação"
     @submit="salvarConfiguracoes"
   >
-    <VaCheckbox v-model="form.viaEmail" label="Receber por e-mail" />
-    <VaCheckbox v-model="form.viaSystem" label="Receber no sistema" />
+    <div
+      v-for="(item, index) in data"
+      :key="item.id"
+      class="mb-6 pb-3 border-b border-gray-200 last:border-b-0 mt-3"
+    >
+      <h6
+        class="text-base font-semibold text-gray-700 mb-2 va-h6"
+        v-if="item.notificationType?.description"
+      >
+        {{ item.notificationType.description }}
+      </h6>
+
+      <div
+        class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-6 pl-2"
+      >
+        <VaCheckbox
+          v-if="item.notificationType.allowEmail"
+          v-model="form[item.notificationType.key].viaEmail"
+          label="Receber por e-mail"
+        />
+        <VaCheckbox
+          v-if="item.notificationType.allowSystem"
+          v-model="form[item.notificationType.key].viaSystem"
+          label="Receber no sistema"
+        />
+      </div>
+    </div>
   </ZFormModal>
 </template>
 
 <script>
 import ZFormModal from "~/components/molecules/Modal/ZFormModal.vue";
+import NOTIFICATIONSETTINGS from "~/graphql/notification-settings/query/notificationSettings.graphql";
 
 export default {
   name: "ZNotificationSettingsForm",
@@ -24,11 +50,12 @@ export default {
   emits: ["update:modelValue"],
   data() {
     return {
-      form: {
-        viaEmail: true,
-        viaSystem: true,
-      },
+      data: [],
+      form: {},
     };
+  },
+  mounted() {
+    this.getNotificationSettings();
   },
   computed: {
     open: {
@@ -44,6 +71,36 @@ export default {
     salvarConfiguracoes() {
       console.log("Salvar configurações de notificação:", this.form);
       this.$emit("update:modelValue", false);
+    },
+
+    getNotificationSettings() {
+      console.log("getNotificationSettings");
+
+      const query = gql`
+        ${NOTIFICATIONSETTINGS}
+      `;
+
+      const consult = {};
+      const { onResult } = useQuery(query, consult);
+
+      onResult((result) => {
+        const settings = result?.data?.notificationsSettings.data;
+        if (Array.isArray(settings)) {
+          this.data = settings;
+
+          this.form = {};
+          settings.forEach((item) => {
+            const key = item.notificationType.key;
+            this.form[key] = {
+              viaEmail: item.viaEmail,
+              viaSystem: item.viaSystem,
+            };
+          });
+        } else {
+          console.warn("notificationsSettings não é um array:", settings);
+          this.data = [];
+        }
+      });
     },
   },
 };

--- a/components/organisms/Settings/ZNotificationSettingsForm.vue
+++ b/components/organisms/Settings/ZNotificationSettingsForm.vue
@@ -23,6 +23,7 @@
           v-if="item.notificationType.allowEmail"
           v-model="form[item.notificationType.key].viaEmail"
           label="Receber por e-mail"
+          class="mb-2 sm:mb-0 mr-5 mt-3"
         />
         <VaCheckbox
           v-if="item.notificationType.allowSystem"

--- a/graphql/notification-settings/mutation/notificationSettingEdit.graphql
+++ b/graphql/notification-settings/mutation/notificationSettingEdit.graphql
@@ -1,0 +1,41 @@
+mutation notificationSettingEdit(
+  $id: ID
+  $notificationTypeId: Int
+  $viaEmail: Boolean
+  $viaSystem: Boolean
+) {
+  notificationSettingEdit(
+    id: $id
+    notificationTypeId: $notificationTypeId
+    viaEmail: $viaEmail
+    viaSystem: $viaSystem
+  ) {
+    id
+    userId
+    notificationTypeId
+    user {
+      id
+      name
+      email
+      userId
+      emailVerifiedAt
+      createdAt
+      updatedAt
+    }
+    viaEmail
+    viaSystem
+    isActive
+    notificationType {
+      id
+      key
+      description
+      allowEmail
+      allowSystem
+      isActive
+      createdAt
+      updatedAt
+    }
+    createdAt
+    updatedAt
+  }
+}

--- a/graphql/notification-settings/query/notificationSettings.graphql
+++ b/graphql/notification-settings/query/notificationSettings.graphql
@@ -1,0 +1,45 @@
+query notificationsSettings(
+    $first: Int,
+    $page: Int
+) {
+  notificationsSettings(
+    first: $first,
+    page: $page
+  ) {
+    paginatorInfo {
+      count
+      currentPage
+      firstItem
+      hasMorePages
+      lastItem
+      lastPage
+      perPage
+      total
+    }
+    data {
+      id
+      userId
+      user {
+        id
+        name
+        email
+      }
+      notificationTypeId
+      viaEmail
+      viaSystem
+      isActive
+      notificationType {
+        id
+        key
+        description
+        allowEmail
+        allowSystem
+        isActive
+        createdAt
+        updatedAt
+      } 
+      createdAt
+      updatedAt
+    }
+  }
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,6 @@
   <va-card color="background-border" class="pb-3" style="height: 100%">
     <ZNavBar
       @toggle-minimize="valueToggle"
-      :menu-settings="menuSettings"
       @menu-settings-minimize="onMenuSettingsMinimize"
     />
 
@@ -31,67 +30,26 @@
     </div>
 
     <!-- Sidebar flutuante à direita -->
-    <VaSidebar
-      v-model="enabledSettings"
-      :minimized="minimizedSettings"
-      class="settings-sidebar"
-      animated="right"
-    >
-      <VaSidebarItem
-        v-for="item in menuSettings"
-        :key="item.title"
-        :active="item.active"
-      >
-        <VaSidebarItemContent
-          @click="handleMenuItemClick(item)"
-          style="cursor: pointer"
-        >
-          <VaIcon :name="item.icon" />
-          <VaSidebarItemTitle>
-            {{ item.title }}
-          </VaSidebarItemTitle>
-        </VaSidebarItemContent>
-      </VaSidebarItem>
-    </VaSidebar>
+    <ZSidebarSettings v-model="enabledSettings" />
   </va-card>
 </template>
 
 <script>
 import ZSidebar from "~/components/molecules/Sidebar/ZSidebar";
+import ZSidebarSettings from "~/components/molecules/Sidebar/ZSidebarSettings";
 import ZNavBar from "~/components/organisms/NavBar/ZNavBar";
 
 export default {
   components: {
     ZSidebar,
     ZNavBar,
+    ZSidebarSettings,
   },
   data() {
     return {
       minimized: false,
       enabledSettings: false,
       minimizedSettings: false, // ✅ adiciona isso aqui
-
-      menuSettings: [
-        {
-          title: "Configurações da Conta",
-          icon: "settings",
-          to: "/settings",
-          active: false,
-        },
-        {
-          title: "Configurações de Notificação",
-          icon: "notifications",
-          to: "/notifications",
-          active: false,
-        },
-        {
-          title: "Fechar Configurações",
-          icon: "close",
-          action: () => {
-            this.enabledSettings = false;
-          },
-        },
-      ],
     };
   },
   methods: {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,13 @@
 <template>
   <va-card color="background-border" class="pb-3" style="height: 100%">
-    <ZNavBar @toggle-minimize="valueToggle" />
+    <ZNavBar
+      @toggle-minimize="valueToggle"
+      :menu-settings="menuSettings"
+      @menu-settings-minimize="onMenuSettingsMinimize"
+    />
+
     <div class="row align-content-start">
+      <!-- Coluna lateral esquerda -->
       <div
         :class="['flex', 'flex-col', minimized ? 'xs1 sm1 md1 lg1 xl1' : 'xs2']"
       >
@@ -9,6 +15,8 @@
           <ZSidebar :toggle="minimized" />
         </div>
       </div>
+
+      <!-- Conteúdo principal -->
       <div
         :class="[
           'flex',
@@ -21,8 +29,33 @@
         </div>
       </div>
     </div>
+
+    <!-- Sidebar flutuante à direita -->
+    <VaSidebar
+      v-model="enabledSettings"
+      :minimized="minimizedSettings"
+      class="settings-sidebar"
+      animated="right"
+    >
+      <VaSidebarItem
+        v-for="item in menuSettings"
+        :key="item.title"
+        :active="item.active"
+      >
+        <VaSidebarItemContent
+          @click="handleMenuItemClick(item)"
+          style="cursor: pointer"
+        >
+          <VaIcon :name="item.icon" />
+          <VaSidebarItemTitle>
+            {{ item.title }}
+          </VaSidebarItemTitle>
+        </VaSidebarItemContent>
+      </VaSidebarItem>
+    </VaSidebar>
   </va-card>
 </template>
+
 <script>
 import ZSidebar from "~/components/molecules/Sidebar/ZSidebar";
 import ZNavBar from "~/components/organisms/NavBar/ZNavBar";
@@ -35,11 +68,45 @@ export default {
   data() {
     return {
       minimized: false,
+      enabledSettings: false,
+      minimizedSettings: false, // ✅ adiciona isso aqui
+
+      menuSettings: [
+        {
+          title: "Configurações da Conta",
+          icon: "settings",
+          to: "/settings",
+          active: false,
+        },
+        {
+          title: "Configurações de Notificação",
+          icon: "notifications",
+          to: "/notifications",
+          active: false,
+        },
+        {
+          title: "Fechar Configurações",
+          icon: "close",
+          action: () => {
+            this.enabledSettings = false;
+          },
+        },
+      ],
     };
   },
   methods: {
     valueToggle(value) {
       this.minimized = value;
+    },
+    onMenuSettingsMinimize() {
+      this.enabledSettings = !this.enabledSettings;
+    },
+    handleMenuItemClick(item) {
+      if (item.action) {
+        item.action.call(this);
+      } else if (item.to) {
+        this.$router.push(item.to);
+      }
     },
   },
 };
@@ -48,5 +115,12 @@ export default {
 <style scoped>
 .margin-menu {
   margin-top: 6rem;
+}
+.settings-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  z-index: 999;
 }
 </style>


### PR DESCRIPTION
### O que?

Antes não havia como ter controle sobre as notificações enviadas por e-mail no sistema.

### Por quê?

Poderia gerar Spam para os usuários.
É um requisito importante na AWS para acesso a produção.

### Como?

Criado as validações via backend, e validado via rota GraphQL as configurações feitas via modal.

### Capturas de tela

Caminho para modal de configuração de notificações no sistema:

![image](https://github.com/user-attachments/assets/a6ff3d45-c428-4594-905b-9b8c4485686c)

![image](https://github.com/user-attachments/assets/313df5fb-89c4-4f68-96d1-56fc89c88138)

![image](https://github.com/user-attachments/assets/e99c5bab-09b7-4dfe-8637-ca6f3a2ce6ac)


### Verificações
- [x] Lembrete: Ajustar o `composer.json` com a versão.

