### PR TITLE
fix(times): implementar o utilitário resolveListRelationDeleteId para tratamento de exclusão consistente em formulários - VT-99

### DIFF
--- a/components/organisms/Forms/Team/ZTeamForm.vue
+++ b/components/organisms/Forms/Team/ZTeamForm.vue
@@ -76,6 +76,7 @@ import ZListRelationUsers from "~/components/organisms/List/Relations/ZListRelat
 import ZSelectTeamCategory from "~/components/molecules/Selects/ZSelectTeamCategory";
 import ZSelectTeamLevel from "~/components/molecules/Selects/ZSelectTeamLevel.vue";
 import { confirmSuccess } from "~/utils/sweetAlert2/swalHelper";
+import { resolveListRelationDeleteId } from "~/utils/resolveListRelationDeleteId";
 
 export default {
   props: {
@@ -151,8 +152,14 @@ export default {
       this.users = [];
     },
 
-    actionDeleteUser(id) {
-      this.form.users = this.form.users.filter((user) => user.id !== id);
+    actionDeleteUser(payload) {
+      const idNum = resolveListRelationDeleteId(payload);
+      if (idNum === null) {
+        return;
+      }
+      this.form.users = this.form.users.filter(
+        (user) => Number(user.id) !== idNum,
+      );
       confirmSuccess("Jogador removido com sucesso!");
     },
 

--- a/components/organisms/Forms/Training/ZTrainingForm.vue
+++ b/components/organisms/Forms/Training/ZTrainingForm.vue
@@ -364,6 +364,7 @@ import ZListRelationFundamentals from "~/components/organisms/List/Relations/ZLi
 import ZListRelationSpecificFundamentals from "~/components/organisms/List/Relations/ZListRelationSpecificFundamentals";
 import ZListRelationTeams from "~/components/organisms/List/Relations/ZListRelationTeams";
 import { confirmSuccess, confirmError } from "~/utils/sweetAlert2/swalHelper";
+import { resolveListRelationDeleteId } from "~/utils/resolveListRelationDeleteId";
 import Swal from "sweetalert2";
 import ZDateTimeRangePicker from "~/components/molecules/Inputs/ZDateTimeRangePicker.vue";
 import ZSelectFundamental from "~/components/molecules/Selects/ZSelectFundamental.vue";
@@ -1220,35 +1221,49 @@ export default {
       this.specificFundamentals = [];
     },
 
-    actionDeletePosition(id) {
-      this.form.positions = this.form.positions.filter((position) => {
-        return position.id !== id;
-      });
+    actionDeletePosition(payload) {
+      const idNum = resolveListRelationDeleteId(payload);
+      if (idNum === null) {
+        return;
+      }
+      this.form.positions = this.form.positions.filter(
+        (position) => Number(position.id) !== idNum,
+      );
 
       confirmSuccess("Posição removida com sucesso!");
     },
 
-    actionDeleteTeam(id) {
-      this.form.teams = this.form.teams.filter((team) => {
-        return team.id !== id;
-      });
+    actionDeleteTeam(payload) {
+      const idNum = resolveListRelationDeleteId(payload);
+      if (idNum === null) {
+        return;
+      }
+      this.form.teams = this.form.teams.filter(
+        (team) => Number(team.id) !== idNum,
+      );
 
       confirmSuccess("Time removido com sucesso!");
     },
 
-    actionDeleteFundamental(id) {
-      this.form.fundamentals = this.form.fundamentals.filter((fundamental) => {
-        return fundamental.id !== id;
-      });
+    actionDeleteFundamental(payload) {
+      const idNum = resolveListRelationDeleteId(payload);
+      if (idNum === null) {
+        return;
+      }
+      this.form.fundamentals = this.form.fundamentals.filter(
+        (fundamental) => Number(fundamental.id) !== idNum,
+      );
 
       confirmSuccess("Fundamento removido com sucesso!");
     },
 
-    actionDeleteSpecificFundamental(id) {
+    actionDeleteSpecificFundamental(payload) {
+      const idNum = resolveListRelationDeleteId(payload);
+      if (idNum === null) {
+        return;
+      }
       this.form.specificFundamentals = this.form.specificFundamentals.filter(
-        (specificFundamental) => {
-          return specificFundamental.id !== id;
-        }
+        (specificFundamental) => Number(specificFundamental.id) !== idNum,
       );
 
       confirmSuccess("Fundamento Específico removido com sucesso!");
@@ -1302,10 +1317,14 @@ export default {
       this.scouts = [];
     },
 
-    actionDeletePlayer(id) {
-      this.form.players = this.form.players.filter((player) => {
-        return player.id !== id;
-      });
+    actionDeletePlayer(payload) {
+      const idNum = resolveListRelationDeleteId(payload);
+      if (idNum === null) {
+        return;
+      }
+      this.form.players = this.form.players.filter(
+        (player) => Number(player.id) !== idNum,
+      );
 
       confirmSuccess("Jogador removido com sucesso!");
     },
@@ -1582,10 +1601,14 @@ export default {
       }
     },
 
-    actionDeleteScout(id) {
-      this.form.scouts = this.form.scouts.filter((scout) => {
-        return scout.id !== id;
-      });
+    actionDeleteScout(payload) {
+      const idNum = resolveListRelationDeleteId(payload);
+      if (idNum === null) {
+        return;
+      }
+      this.form.scouts = this.form.scouts.filter(
+        (scout) => Number(scout.id) !== idNum,
+      );
 
       confirmSuccess("Scout removido com sucesso!");
     },

--- a/components/organisms/Forms/User/ZUserForm.vue
+++ b/components/organisms/Forms/User/ZUserForm.vue
@@ -231,6 +231,7 @@ import ROLES from "~/graphql/role/query/roles.graphql";
 import { gql } from "@apollo/client/core";
 import { useNuxtApp } from "#app";
 import { confirmSuccess } from "~/utils/sweetAlert2/swalHelper";
+import { resolveListRelationDeleteId } from "~/utils/resolveListRelationDeleteId";
 
 const ROLE_ICONS = {
   Administrador: "shield",
@@ -455,12 +456,16 @@ export default {
 
       this.positions = [];
     },
-    actionDeletePosition(position) {
+    actionDeletePosition(payload) {
+      const idNum = resolveListRelationDeleteId(payload);
+      if (idNum === null) {
+        return;
+      }
       if (!Array.isArray(this.form.positions)) {
         this.form.positions = [];
       }
       this.form.positions = this.form.positions.filter(
-        (p) => p.id !== position.id,
+        (p) => Number(p.id) !== idNum,
       );
     },
     goBack() {

--- a/components/organisms/List/Relations/ZListRelationConfirmationTrainings.vue
+++ b/components/organisms/List/Relations/ZListRelationConfirmationTrainings.vue
@@ -150,6 +150,7 @@ import ZDatatableGeneric from "~/components/molecules/Datatable/ZDatatableGeneri
 import ZUser from "~/components/molecules/Datatable/Slots/ZUser";
 import ZButton from "~/components/atoms/Buttons/ZButton";
 import ME from "~/graphql/user/query/me.graphql";
+import { resolveListRelationDeleteId } from "~/utils/resolveListRelationDeleteId";
 
 export default {
   components: {
@@ -202,8 +203,12 @@ export default {
     add() {
       this.$emit("add");
     },
-    actionDelete(item) {
-      this.$emit("delete", item);
+    actionDelete(payload) {
+      const id = resolveListRelationDeleteId(payload);
+      if (id === null) {
+        return;
+      }
+      this.$emit("delete", id);
     },
     actionConfirm(id, playerId, trainingId) {
       this.$emit("actionConfirm", id, playerId, trainingId);

--- a/components/organisms/List/Relations/ZListRelationFundamentals.vue
+++ b/components/organisms/List/Relations/ZListRelationFundamentals.vue
@@ -33,6 +33,7 @@
 import ZListRelationGeneric from "~/components/molecules/List/ZListRelationGeneric";
 import ZDatatableGeneric from "~/components/molecules/Datatable/ZDatatableGeneric";
 import ZTeam from "~/components/molecules/Datatable/Slots/ZTeam";
+import { resolveListRelationDeleteId } from "~/utils/resolveListRelationDeleteId";
 
 export default {
   components: {
@@ -85,8 +86,12 @@ export default {
     add() {
       this.$emit("add");
     },
-    actionDelete(item) {
-      this.$emit("delete", item);
+    actionDelete(payload) {
+      const id = resolveListRelationDeleteId(payload);
+      if (id === null) {
+        return;
+      }
+      this.$emit("delete", id);
     },
   },
 };

--- a/components/organisms/List/Relations/ZListRelationPositions.vue
+++ b/components/organisms/List/Relations/ZListRelationPositions.vue
@@ -29,6 +29,7 @@
 <script>
 import ZListRelationGeneric from "~/components/molecules/List/ZListRelationGeneric";
 import ZDatatableGeneric from "~/components/molecules/Datatable/ZDatatableGeneric";
+import { resolveListRelationDeleteId } from "~/utils/resolveListRelationDeleteId";
 
 export default {
   components: {
@@ -111,8 +112,12 @@ export default {
     add() {
       this.$emit("add");
     },
-    actionDelete(item) {
-      this.$emit("delete", item);
+    actionDelete(payload) {
+      const id = resolveListRelationDeleteId(payload);
+      if (id === null) {
+        return;
+      }
+      this.$emit("delete", id);
     },
   },
 };

--- a/components/organisms/List/Relations/ZListRelationSpecificFundamentals.vue
+++ b/components/organisms/List/Relations/ZListRelationSpecificFundamentals.vue
@@ -33,6 +33,7 @@
 import ZListRelationGeneric from "~/components/molecules/List/ZListRelationGeneric";
 import ZDatatableGeneric from "~/components/molecules/Datatable/ZDatatableGeneric";
 import ZTeam from "~/components/molecules/Datatable/Slots/ZTeam";
+import { resolveListRelationDeleteId } from "~/utils/resolveListRelationDeleteId";
 
 export default {
   components: {
@@ -85,8 +86,12 @@ export default {
     add() {
       this.$emit("add");
     },
-    actionDelete(item) {
-      this.$emit("delete", item);
+    actionDelete(payload) {
+      const id = resolveListRelationDeleteId(payload);
+      if (id === null) {
+        return;
+      }
+      this.$emit("delete", id);
     },
   },
 };

--- a/components/organisms/List/Relations/ZListRelationTeams.vue
+++ b/components/organisms/List/Relations/ZListRelationTeams.vue
@@ -33,6 +33,7 @@
 import ZListRelationGeneric from "~/components/molecules/List/ZListRelationGeneric";
 import ZDatatableGeneric from "~/components/molecules/Datatable/ZDatatableGeneric";
 import ZTeam from "~/components/molecules/Datatable/Slots/ZTeam";
+import { resolveListRelationDeleteId } from "~/utils/resolveListRelationDeleteId";
 
 export default {
   components: {
@@ -123,8 +124,12 @@ export default {
     add() {
       this.$emit("add");
     },
-    actionDelete(item) {
-      this.$emit("delete", item);
+    actionDelete(payload) {
+      const id = resolveListRelationDeleteId(payload);
+      if (id === null) {
+        return;
+      }
+      this.$emit("delete", id);
     },
   },
 };

--- a/components/organisms/List/Relations/ZListRelationUsers.vue
+++ b/components/organisms/List/Relations/ZListRelationUsers.vue
@@ -34,6 +34,7 @@
 
 <script>
 import ZListRelationGeneric from "~/components/molecules/List/ZListRelationGeneric";
+import { confirmDeleteSingle } from "~/utils/sweetAlert2/swalHelper";
 
 export default {
   components: {
@@ -70,7 +71,9 @@ export default {
       this.$emit("add");
     },
     actionDelete(id) {
-      this.$emit("delete", id);
+      confirmDeleteSingle(() => {
+        this.$emit("delete", id);
+      });
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "2.6.1",
+  "version": "2.7.0",
   "scripts": {
     "build": "nuxt build",
     "dev": "NODE_OPTIONS='--no-deprecation' nuxt dev",

--- a/pages/teams/edit/[id].vue
+++ b/pages/teams/edit/[id].vue
@@ -1,11 +1,17 @@
 <template>
-  <ZTeamForm
-    :data="data"
-    @save="edit"
-    :loading="loading"
-    :errorFields="errorFields"
-    :errors="errors"
-  />
+  <div class="edit-team-page">
+    <div class="page-header">
+      <h1 class="title">Editar Time</h1>
+      <p class="subtitle">Atualize as informações do time e dos jogadores relacionados</p>
+    </div>
+    <ZTeamForm
+      :data="data"
+      @save="edit"
+      :loading="loading"
+      :errorFields="errorFields"
+      :errors="errors"
+    />
+  </div>
 </template>
 
 <script>
@@ -86,7 +92,10 @@ export default {
         const variables = {
           id: form.id,
           name: form.name,
-          playerId: form.users.map((item) => item.id),
+          playerId: (Array.isArray(form.users) ? form.users : [])
+            .map((item) => item?.id)
+            .filter((id) => id != null && id !== "")
+            .map((id) => Number(id)),
           teamCategoryId: form.teamCategory?.value || form.teamCategory?.id,
           teamLevelId: form.teamLevel?.value || form.teamLevel?.id,
         };
@@ -137,3 +146,25 @@ useHead({
   titleTemplate: "Editar Time",
 });
 </script>
+
+<style scoped>
+.edit-team-page {
+  width: 100%;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.title {
+  font-size: 30px;
+  font-weight: bold;
+  color: #0b1e3a;
+}
+
+.subtitle {
+  font-size: 16px;
+  color: #6c757d;
+}
+</style>

--- a/utils/resolveListRelationDeleteId.js
+++ b/utils/resolveListRelationDeleteId.js
@@ -1,0 +1,18 @@
+/**
+ * ZDatatableGeneric / ZDataTableActions emitem o id numérico da linha.
+ * Mantém compatibilidade se algo repassar { id: n }.
+ *
+ * @param {number|string|{ id?: number|string }|null|undefined} payload
+ * @returns {number|null}
+ */
+export function resolveListRelationDeleteId (payload) {
+  if (payload == null || payload === '') {
+    return null
+  }
+  if (typeof payload === 'object' && payload !== null && payload.id != null && payload.id !== '') {
+    const n = Number(payload.id)
+    return Number.isNaN(n) ? null : n
+  }
+  const n = Number(payload)
+  return Number.isNaN(n) ? null : n
+}


### PR DESCRIPTION
### Jira

[VT-99](https://zorensoftware.atlassian.net/browse/VT-99)

### O que?
- Adicionado o utilitário resolveListRelationDeleteId para padronizar a extração de ID de cargas úteis para ações de exclusão.
- Métodos actionDelete atualizados em vários componentes (ZTeamForm, ZTrainingForm, ZUserForm, etc.) para utilizar o novo utilitário para maior confiabilidade e consistência de código.
- Experiência do usuário aprimorada, garantindo que as ações de exclusão manipulem IDs diretos e objetos com propriedades de ID.


### Verificações
- [x] Lembrete: Ajustar o `composer.json` com a versão.



[VT-99]: https://zorensoftware.atlassian.net/browse/VT-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ