### PR TITLE
fix(filtro): ajustar status padrão para null na listagem de treinos - VT-104

### DIFF
--- a/components/organisms/Datatables/Trainings/ZDatatablesTrainings.vue
+++ b/components/organisms/Datatables/Trainings/ZDatatablesTrainings.vue
@@ -129,13 +129,24 @@
           @click="deleteBulkCreatedTrainings"
         >
           <va-icon name="delete" class="button-icon" />
-          <span class="button-text">Deletar Treinos em Massa Selecionados ({{ selectedBulkTrainings.length }})</span>
+          <span class="button-text"
+            >Deletar Treinos em Massa Selecionados ({{
+              selectedBulkTrainings.length
+            }})</span
+          >
         </va-button>
       </template>
       <!-- CELL -->
       <template
         #cell(name)="{
-          rowKey: { id, name, dateStart, status, displayStatus, confirmationTrainingMetrics },
+          rowKey: {
+            id,
+            name,
+            dateStart,
+            status,
+            displayStatus,
+            confirmationTrainingMetrics,
+          },
         }"
       >
         <ZTraining
@@ -272,7 +283,7 @@ export default defineComponent({
       variablesGetTrainings: {
         page: 1,
         filter: {
-          status: "PENDING", // Padrão: treinos agendados
+          status: null,
           teamsIds: [],
           usersIds: [],
           playersIds: [],
@@ -284,7 +295,6 @@ export default defineComponent({
         sortedBy: "desc",
       },
       statusOptions: [
-        { label: "Todos", value: null },
         { label: "Agendado", value: "PENDING" },
         { label: "Finalizado", value: "FINISHED" },
         { label: "Cancelado", value: "CANCELLED" },
@@ -305,7 +315,11 @@ export default defineComponent({
       // Filtrar apenas treinos criados em massa que estão selecionados
       // Verificar tanto isBulkCreated === true quanto isBulkCreated === 1 (caso venha como número do banco)
       return this.selectedItemsEmitted.filter((item) => {
-        return item.isBulkCreated === true || item.isBulkCreated === 1 || item.isBulkCreated === '1';
+        return (
+          item.isBulkCreated === true ||
+          item.isBulkCreated === 1 ||
+          item.isBulkCreated === "1"
+        );
       });
     },
     hasBulkCreatedSelected() {
@@ -315,7 +329,7 @@ export default defineComponent({
 
   watch: {
     // Observar mudanças no status e executar busca automaticamente
-    'variablesGetTrainings.filter.status'(newStatus, oldStatus) {
+    "variablesGetTrainings.filter.status"(newStatus, oldStatus) {
       // Evitar busca na inicialização (quando oldStatus é undefined)
       if (oldStatus !== undefined && newStatus !== oldStatus) {
         // Resetar para primeira página quando mudar o filtro
@@ -343,7 +357,7 @@ export default defineComponent({
     async deleteBulkCreatedTraining(id) {
       // Encontrar o treino para obter informações
       const training = this.items.find((item) => item.id === id);
-      
+
       if (!training) {
         confirmError("Treino não encontrado");
         return;
@@ -352,11 +366,11 @@ export default defineComponent({
       // Formatar a data do treino para exibir na confirmação
       const trainingDate = moment(training.dateStart).format("DD/MM/YYYY");
       const trainingTime = moment(training.dateStart).format("HH:mm");
-      
+
       try {
         // Buscar a contagem exata de treinos que serão deletados
         this.loading = true;
-        
+
         const countQuery = gql`
           ${TRAININGBULKDELETECOUNT}
         `;
@@ -369,7 +383,7 @@ export default defineComponent({
           onResult((result) => {
             const countToDelete = result?.data?.trainingBulkDeleteCount || 0;
             this.loading = false;
-            
+
             // Mostrar confirmação antes de deletar com informações sobre a data e quantidade
             this.showBulkDeleteConfirmation(
               trainingDate,
@@ -396,7 +410,7 @@ export default defineComponent({
                     `${deletedCount} treino(s) deletado(s) com sucesso!`,
                     () => {
                       this.getTrainings({ fetchPolicy: "network-only" });
-                    }
+                    },
                   );
                 } catch (error) {
                   console.error(error);
@@ -408,19 +422,26 @@ export default defineComponent({
                     error.graphQLErrors[0].extensions &&
                     error.graphQLErrors[0].extensions.validation
                   ) {
-                    const errorMessages = Object.values(error.graphQLErrors[0].extensions.validation)
+                    const errorMessages = Object.values(
+                      error.graphQLErrors[0].extensions.validation,
+                    )
                       .flat()
                       .filter((msg) => msg);
 
-                    confirmError("Erro ao deletar treinos em massa!", errorMessages);
+                    confirmError(
+                      "Erro ao deletar treinos em massa!",
+                      errorMessages,
+                    );
                   } else {
-                    const errorMessage = error.graphQLErrors?.[0]?.message || "Erro ao deletar treinos em massa!";
+                    const errorMessage =
+                      error.graphQLErrors?.[0]?.message ||
+                      "Erro ao deletar treinos em massa!";
                     confirmError(errorMessage);
                   }
                 } finally {
                   this.loading = false;
                 }
-              }
+              },
             );
             resolve();
           });
@@ -470,7 +491,7 @@ export default defineComponent({
     },
     unselectItem(item) {
       this.selectedItems = this.selectedItems.filter(
-        (selectedItem) => selectedItem !== item
+        (selectedItem) => selectedItem !== item,
       );
     },
     addTraining() {
@@ -567,7 +588,7 @@ export default defineComponent({
     clearSearch() {
       this.internalSearchValue = "";
       this.variablesGetTrainings.filter = {
-        status: "PENDING", // Padrão: treinos agendados
+        status: null,
         teamsIds: [],
         usersIds: [],
         playersIds: [],
@@ -589,17 +610,17 @@ export default defineComponent({
 
       let teamsIdsValues =
         this.variablesGetTrainings.filter.teamsIds?.map((team) =>
-          parseInt(team?.value || team)
+          parseInt(team?.value || team),
         ) || [];
 
       let usersIdsValues =
         this.variablesGetTrainings.filter.usersIds?.map((user) =>
-          parseInt(user?.value || user)
+          parseInt(user?.value || user),
         ) || [];
 
       let playersIdsValues =
         this.variablesGetTrainings.filter.playersIds?.map((player) =>
-          parseInt(player?.value || player)
+          parseInt(player?.value || player),
         ) || [];
 
       let dateEnd = this.variablesGetTrainings.filter.dateEnd;
@@ -616,16 +637,19 @@ export default defineComponent({
 
       // Preparar filtro de status
       const filterData = {
-          ...this.variablesGetTrainings.filter,
-          teamsIds: teamsIdsValues,
-          usersIds: usersIdsValues,
-          playersIds: playersIdsValues,
-          dateStart,
-          dateEnd,
+        ...this.variablesGetTrainings.filter,
+        teamsIds: teamsIdsValues,
+        usersIds: usersIdsValues,
+        playersIds: playersIdsValues,
+        dateStart,
+        dateEnd,
       };
 
       // Adicionar status apenas se não for null (todos)
-      if (this.variablesGetTrainings.filter.status && this.variablesGetTrainings.filter.status !== null) {
+      if (
+        this.variablesGetTrainings.filter.status &&
+        this.variablesGetTrainings.filter.status !== null
+      ) {
         filterData.status = this.variablesGetTrainings.filter.status;
       }
 


### PR DESCRIPTION
### Jira

[VT-104](https://zorensoftware.atlassian.net/browse/VT-104)

### O que?

Ajustado opção do filtro padrão.

### Por quê?

Não estava legal mudamos o layout.


### Capturas de tela

<img width="3011" height="1368" alt="image" src="https://github.com/user-attachments/assets/eb6f08d2-4ced-4f59-87a5-bdb63b1eef21" />


### Verificações
- [ ] Lembrete: Ajustar o `composer.json` com a versão.



[VT-104]: https://zorensoftware.atlassian.net/browse/VT-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ