### PR TITLE
feat(layout): adicionar versão da aplicação no rodapé da sidebar - VT-109

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -110,6 +110,9 @@
           </div>
         </div>
       </nav>
+      <div class="sidebar-footer">
+        <span class="sidebar-version">v{{ appVersion }}</span>
+      </div>
     </aside>
     <div class="main-area">
       <div class="top-bar">
@@ -208,6 +211,7 @@ import ZListItemsUser from "~/components/molecules/List/ZListItemsUser.vue";
 import NOTIFICATIONSTOTAL from "~/graphql/notification/query/notificationsTotal.graphql";
 import ME from "~/graphql/user/query/me.graphql";
 import { getActivePlan } from "~/services/stripeCheckoutService.js";
+import { version as appVersion } from "~/package.json";
 
 export default {
   components: {
@@ -234,6 +238,7 @@ export default {
         roles: [],
       },
       activePlanData: null,
+      appVersion,
     };
   },
   computed: {
@@ -711,7 +716,7 @@ export default {
   flex-direction: column;
   background-color: #0b1e3a;
   border-right: 1px solid #1e3a5f;
-  padding: 20px 16px;
+  padding: 20px 16px 8px;
   box-sizing: border-box;
   z-index: 1001;
   position: fixed;
@@ -1350,6 +1355,33 @@ export default {
 
 .sidebar--collapsed .sidebar-nav {
   margin-top: 0px;
+}
+
+/* ── Rodapé da Sidebar ── */
+.sidebar-footer {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 0 4px;
+  overflow: hidden;
+}
+
+.sidebar-version {
+  font-size: 12px;
+  color: rgba(232, 238, 247, 0.3);
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 120px;
+  opacity: 1;
+  transition:
+    opacity 0.15s cubic-bezier(0.4, 0, 0.2, 1),
+    max-width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.sidebar--collapsed .sidebar-version {
+  max-width: 0;
+  opacity: 0;
 }
 
 /* ── Mobile Hamburger (só visível em mobile) ── */

--- a/layouts/login.vue
+++ b/layouts/login.vue
@@ -12,6 +12,7 @@
           </div>
         </div>
       </div>
+      <div class="login-version">v{{ appVersion }}</div>
     </div>
     <div class="flex flex-col md6 vuestic-hide-on-xs">
       <va-carousel
@@ -28,9 +29,12 @@
 </template>
 
 <script>
+import { version as appVersion } from "~/package.json";
+
 export default {
   data() {
     return {
+      appVersion,
       items: [
         "/images/balls/ball-1.jpg",
         "/images/balls/ball-2.jpg",
@@ -54,5 +58,17 @@ export default {
 
 .custom-width {
   min-width: 54rem !important;
+}
+
+.login-version {
+  position: absolute;
+  bottom: 16px;
+  left: 0;
+  width: 50%;
+  text-align: center;
+  font-size: 11px;
+  color: rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+  user-select: none;
 }
 </style>


### PR DESCRIPTION
### Jira

[VT-109](https://zorensoftware.atlassian.net/browse/VT-109)

### O que?

Ver versão do front no sistema.

### Por quê?

Precisamos ver a versão do front.

### Capturas de tela

<img width="1395" height="2014" alt="image" src="https://github.com/user-attachments/assets/bec80122-e616-4f62-9d76-948c8e1d3640" />

<img width="1567" height="2004" alt="image" src="https://github.com/user-attachments/assets/10799b14-bf58-45d7-8b9a-5f8af405d622" />


### Verificações
- [ ] Lembrete: Ajustar o `composer.json` com a versão.



[VT-109]: https://zorensoftware.atlassian.net/browse/VT-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ