### PR TITLE
feat(LGPD): implementação politicas de privacidade - VT-120

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,7 @@ NUXT_PUBLIC_LOGIN_TEST_PASSWORD=password
 # Se não der para localizar (ex.: localhost), o padrão é BR (preços BRL).
 NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_IP_COUNTRY=
 NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_BILLING_COUNTRY=
+
+# URL canônica da política de privacidade (landing). Em dev local: http://localhost:3001/privacy-policy
+# Deixe em branco ou comente para usar o padrão (https://volleytrack.com/privacy-policy).
+NUXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost:3001/privacy-policy

--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,10 @@ APP_ENV=local
 # Credenciais de teste para login (apenas desenvolvimento)
 NUXT_PUBLIC_LOGIN_TEST_EMAIL=support@volleytrack.com
 NUXT_PUBLIC_LOGIN_TEST_PASSWORD=password
+
+# Opcional: forçar país na listagem/checkout (testes). Se vazio, o app infere pelo IP
+# (rota /api/volleytrack/detect-ip-country: CF-IPCountry, depois ipwho.is, geojs, country.is,
+# ip-api.com HTTP, ipapi.co — gratuitas; se todas falharem ou IP local → BR / BRL).
+# Se não der para localizar (ex.: localhost), o padrão é BR (preços BRL).
+NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_IP_COUNTRY=
+NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_BILLING_COUNTRY=

--- a/components/organisms/Footer/ZLegalLinks.vue
+++ b/components/organisms/Footer/ZLegalLinks.vue
@@ -1,0 +1,56 @@
+<template>
+  <a
+    :href="privacyPolicyUrl"
+    class="legal-links__anchor"
+    :class="`legal-links__anchor--${variant}`"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    Política de Privacidade
+  </a>
+</template>
+
+<script setup>
+defineProps({
+  variant: {
+    type: String,
+    default: "dark",
+    validator: (value) => ["light", "dark"].includes(value),
+  },
+});
+
+const config = useRuntimeConfig();
+const privacyPolicyUrl = computed(() => {
+  const url = String(config.public.privacyPolicyUrl ?? "").trim();
+  return url || "https://volleytrack.com/privacy-policy";
+});
+</script>
+
+<style scoped>
+.legal-links__anchor {
+  font-size: 12px;
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+  white-space: nowrap;
+}
+
+.legal-links__anchor:hover {
+  text-decoration: underline;
+}
+
+.legal-links__anchor--dark {
+  color: rgba(232, 238, 247, 0.55);
+}
+
+.legal-links__anchor--dark:hover {
+  color: rgba(232, 238, 247, 0.85);
+}
+
+.legal-links__anchor--light {
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.legal-links__anchor--light:hover {
+  color: rgba(0, 0, 0, 0.7);
+}
+</style>

--- a/composables/useVolleytrackPricingTestOverride.js
+++ b/composables/useVolleytrackPricingTestOverride.js
@@ -1,0 +1,117 @@
+import { fetchVolleytrackGeoCountryOnce } from "~/utils/volleytrackGeoIp.js";
+
+const DEFAULT_PRICING_COUNTRY = "BR";
+
+/**
+ * Sobrescreve país de exibição/preço (UI) e envio opcional para o backend em testes locais.
+ *
+ * .env (Nuxt público):
+ *   NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_IP_COUNTRY=US
+ *   NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_BILLING_COUNTRY=BR
+ *
+ * Prioridade: variável de ambiente > query ?ip_country= na rota > país pelo IP (API interna).
+ */
+export function useVolleytrackPricingTestOverride() {
+  const runtimeConfig = useRuntimeConfig();
+  const route = useRoute();
+  const nuxtApp = useNuxtApp();
+
+  const normalize2 = (value) => {
+    if (value === undefined || value === null || value === "") {
+      return null;
+    }
+    const s = String(value).trim().toUpperCase();
+    return s.length >= 2 ? s.slice(0, 2) : null;
+  };
+
+  const forcedIpCountry = computed(() =>
+    normalize2(runtimeConfig.public.volleytrackForcePricingIpCountry),
+  );
+
+  const forcedBillingCountry = computed(() =>
+    normalize2(runtimeConfig.public.volleytrackForcePricingBillingCountry),
+  );
+
+  const skipGeoLookup = computed(
+    () =>
+      Boolean(forcedIpCountry.value) || Boolean(forcedBillingCountry.value),
+  );
+
+  const { data: geoLookup } = useAsyncData(
+    "volleytrack-detect-ip-country",
+    async () => {
+      if (skipGeoLookup.value) {
+        return { countryCode: null, skipped: true };
+      }
+      const code = await fetchVolleytrackGeoCountryOnce(nuxtApp.$fetch);
+
+      return { countryCode: code, skipped: false };
+    },
+    { server: false, lazy: false },
+  );
+
+  const geoIpCountry = computed(() => {
+    if (geoLookup.value?.skipped) {
+      return null;
+    }
+
+    return normalize2(geoLookup.value?.countryCode);
+  });
+
+  const isPricingOverrideActive = computed(
+    () =>
+      Boolean(forcedIpCountry.value || forcedBillingCountry.value) ||
+      !skipGeoLookup.value,
+  );
+
+  /**
+   * País usado em GET /v1/products?ip_country= (prévia regional na listagem).
+   */
+  const effectivePricingIpCountry = computed(() => {
+    if (forcedIpCountry.value) {
+      return forcedIpCountry.value;
+    }
+    const q = route.query.ip_country;
+    const fromQuery = normalize2(q);
+    if (fromQuery) {
+      return fromQuery;
+    }
+
+    const g = geoIpCountry.value;
+    if (g) {
+      return g;
+    }
+    if (skipGeoLookup.value) {
+      return null;
+    }
+
+    return DEFAULT_PRICING_COUNTRY;
+  });
+
+  /** País de cobrança exibido na UI quando não há override explícito no .env. */
+  const effectivePricingBillingCountry = computed(() => {
+    if (forcedBillingCountry.value) {
+      return forcedBillingCountry.value;
+    }
+
+    const g = geoIpCountry.value;
+    if (g) {
+      return g;
+    }
+    if (skipGeoLookup.value) {
+      return null;
+    }
+
+    return DEFAULT_PRICING_COUNTRY;
+  });
+
+  return {
+    forcedIpCountry,
+    forcedBillingCountry,
+    geoIpCountry,
+    isPricingOverrideActive,
+    effectivePricingIpCountry,
+    effectivePricingBillingCountry,
+    normalize2,
+  };
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -127,6 +127,7 @@
         </div>
       </nav>
       <div class="sidebar-footer">
+        <ZLegalLinks variant="dark" class="sidebar-legal-links" />
         <span class="sidebar-version">v{{ appVersion }}</span>
       </div>
     </aside>
@@ -216,6 +217,9 @@
       </div>
       <div class="content-wrapper">
         <NuxtPage />
+        <footer class="app-main-footer">
+          <ZLegalLinks variant="light" />
+        </footer>
       </div>
     </div>
   </div>
@@ -224,6 +228,7 @@
 <script>
 import ZListItemsNotification from "~/components/organisms/List/Notification/ZListItemsNotification.vue";
 import ZListItemsUser from "~/components/molecules/List/ZListItemsUser.vue";
+import ZLegalLinks from "~/components/organisms/Footer/ZLegalLinks.vue";
 import NOTIFICATIONSTOTAL from "~/graphql/notification/query/notificationsTotal.graphql";
 import ME from "~/graphql/user/query/me.graphql";
 import { getActivePlan } from "~/services/stripeCheckoutService.js";
@@ -233,6 +238,7 @@ export default {
   components: {
     ZListItemsNotification,
     ZListItemsUser,
+    ZLegalLinks,
   },
   data() {
     return {
@@ -849,6 +855,20 @@ export default {
   transition: margin-left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.content-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.app-main-footer {
+  flex-shrink: 0;
+  display: flex;
+  justify-content: center;
+  padding: 12px 16px 20px;
+}
+
 .sidebar-is-collapsed .main-area {
   margin-left: 64px;
 }
@@ -1298,16 +1318,6 @@ export default {
   color: #0b1e3a;
   cursor: pointer;
 }
-.content-wrapper {
-  flex: 1;
-  padding: 20px;
-  overflow-x: hidden;
-  width: 100%;
-  box-sizing: border-box;
-  position: relative;
-  z-index: 0;
-  min-height: 0;
-}
 
 /* ── Sidebar Toggle Button ── */
 .sidebar-toggle-btn {
@@ -1380,10 +1390,25 @@ export default {
 .sidebar-footer {
   flex-shrink: 0;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 6px;
   padding: 12px 0 4px;
   overflow: hidden;
+}
+
+.sidebar-legal-links {
+  max-width: 100%;
+  overflow: hidden;
+  opacity: 1;
+  transition:
+    opacity 0.15s cubic-bezier(0.4, 0, 0.2, 1),
+    max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.sidebar--collapsed .sidebar-legal-links {
+  display: none;
 }
 
 .sidebar-version {

--- a/layouts/login.vue
+++ b/layouts/login.vue
@@ -12,7 +12,10 @@
           </div>
         </div>
       </div>
-      <div class="login-version">v{{ appVersion }}</div>
+      <div class="login-footer">
+        <ZLegalLinks variant="light" />
+        <span class="login-version">v{{ appVersion }}</span>
+      </div>
     </div>
     <div class="flex flex-col md6 vuestic-hide-on-xs">
       <va-carousel
@@ -30,8 +33,12 @@
 
 <script>
 import { version as appVersion } from "~/package.json";
+import ZLegalLinks from "~/components/organisms/Footer/ZLegalLinks.vue";
 
 export default {
+  components: {
+    ZLegalLinks,
+  },
   data() {
     return {
       appVersion,
@@ -60,15 +67,22 @@ export default {
   min-width: 54rem !important;
 }
 
-.login-version {
+.login-footer {
   position: absolute;
   bottom: 16px;
   left: 0;
   width: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
   text-align: center;
+}
+
+.login-version {
   font-size: 11px;
   color: rgba(0, 0, 0, 0.25);
-  pointer-events: none;
   user-select: none;
+  pointer-events: none;
 }
 </style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -100,6 +100,15 @@ export default defineNuxtConfig({
         process.env.NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_IP_COUNTRY || '',
       volleytrackForcePricingBillingCountry:
         process.env.NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_BILLING_COUNTRY || '',
+      // Mesma ideia do apiEndpoint: process.env + .env (parsed) + fallback. Ignora string vazia.
+      privacyPolicyUrl: (() => {
+        const raw =
+          process.env.NUXT_PUBLIC_PRIVACY_POLICY_URL ||
+          env.NUXT_PUBLIC_PRIVACY_POLICY_URL ||
+          ''
+        const trimmed = String(raw).trim()
+        return trimmed || 'https://volleytrack.com/privacy-policy'
+      })(),
     }
   },
   vuestic: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -95,6 +95,11 @@ export default defineNuxtConfig({
       // Credenciais de teste para login (apenas desenvolvimento)
       loginTestEmail: '',    // pode ser sobrescrito por NUXT_PUBLIC_LOGIN_TEST_EMAIL no .env
       loginTestPassword: '', // pode ser sobrescrito por NUXT_PUBLIC_LOGIN_TEST_PASSWORD no .env
+      // Testes: forçar faixa BR/US na listagem de planos e enviar headers no checkout (ex.: US + cartão BR)
+      volleytrackForcePricingIpCountry:
+        process.env.NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_IP_COUNTRY || '',
+      volleytrackForcePricingBillingCountry:
+        process.env.NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_BILLING_COUNTRY || '',
     }
   },
   vuestic: {

--- a/pages/payment/index.vue
+++ b/pages/payment/index.vue
@@ -6,6 +6,24 @@
       <p>Validando e-mail...</p>
     </div>
     <div v-else class="container">
+      <div
+        v-if="showVolleytrackRegionalDevBanner"
+        class="pricing-override-banner"
+        role="status"
+      >
+        <strong>Preço por região:</strong>
+        listagem como
+        <code>{{ effectivePricingIpCountry ?? "—" }}</code>
+        <template v-if="forcedBillingCountry">
+          · billing (env)
+          <code>{{ forcedBillingCountry }}</code>
+        </template>
+        <template v-else-if="effectivePricingBillingCountry && !forcedBillingCountry">
+          · billing (IP ou padrão BR)
+          <code>{{ effectivePricingBillingCountry }}</code>
+        </template>
+        (valor cobrado no Stripe segue o cartão; use cartões de teste por país).
+      </div>
       <!-- Mensagem de Sucesso Discreta (Canto Inferior Esquerdo) -->
       <div
         v-if="emailValidation.validated && emailValidation.valid"
@@ -241,18 +259,22 @@
         <div v-else>
           <p><strong>Usuário:</strong> Não logado</p>
         </div>
-        <div v-if="selectedPlan && selectedPlan.prices?.data?.[0]">
-          <p><strong>Price ID:</strong> {{ selectedPlan.prices.data[0].id }}</p>
+        <div v-if="selectedPlan && getPlanPrimaryPrice(selectedPlan)">
           <p>
-            <strong>Price Amount:</strong> R$ {{ getPlanPrice(selectedPlan) }}
+            <strong>Price ID:</strong> {{ getPlanPrimaryPrice(selectedPlan).id }}
           </p>
           <p>
-            <strong>Price Type:</strong> {{ selectedPlan.prices.data[0].type }}
+            <strong>Price Amount:</strong>
+            {{ formatPlanMoney(selectedPlan) }}
           </p>
-          <p v-if="selectedPlan.prices.data[0].recurring">
+          <p>
+            <strong>Price Type:</strong>
+            {{ getPlanPrimaryPrice(selectedPlan).type }}
+          </p>
+          <p v-if="getPlanPrimaryPrice(selectedPlan).recurring">
             <strong>Recurring:</strong>
-            {{ selectedPlan.prices.data[0].recurring.interval_count }}
-            {{ selectedPlan.prices.data[0].recurring.interval }}
+            {{ getPlanPrimaryPrice(selectedPlan).recurring.interval_count }}
+            {{ getPlanPrimaryPrice(selectedPlan).recurring.interval }}
           </p>
         </div>
       </div>
@@ -320,9 +342,9 @@
               <div class="plan-card-hero">
                 <div class="plan-price-modern">
                   <div class="plan-price-line">
-                    <span class="price-amount"
-                      >R$ {{ getPlanPrice(plan) }}</span
-                    >
+                    <span class="price-amount">{{
+                      formatPlanMoney(plan)
+                    }}</span>
                     <template v-if="getPlanPeriod(plan)">
                       <span class="price-sep" aria-hidden="true">|</span>
                       <span class="price-period-label">{{
@@ -342,7 +364,7 @@
                     "
                     class="price-yearly"
                   >
-                    ou R$ {{ getYearlyPrice(plan) }}/ano
+                    ou {{ formatYearlyAlternateMoney(plan) }}/ano
                   </span>
                 </div>
 
@@ -552,10 +574,10 @@
                           hasPurchasedLifetimePlan()
                         ? "💎 Plano Vitalício já comprado"
                         : canSwapPlan
-                          ? `🔄 Trocar para ${selectedPlan.name} - R$ ${getPlanPrice(
+                          ? `🔄 Trocar para ${selectedPlan.name} - ${formatPlanMoney(
                               selectedPlan,
                             )}${getPlanPeriod(selectedPlan)}`
-                          : `Assinar ${selectedPlan.name} - R$ ${getPlanPrice(
+                          : `Assinar ${selectedPlan.name} - ${formatPlanMoney(
                               selectedPlan,
                             )}${getPlanPeriod(selectedPlan)}`
             }}
@@ -611,7 +633,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from "vue";
+import { ref, computed, onMounted, nextTick, watch } from "vue";
 import { loadStripe } from "@stripe/stripe-js";
 import {
   createCheckoutSession,
@@ -627,6 +649,7 @@ import BillingFormModal from "~/components/BillingFormModal.vue";
 import PaymentMethodCard from "~/components/PaymentMethodCard.vue";
 import PlanLimitErrorModal from "~/components/PlanLimitErrorModal.vue";
 import { usePlanLimitError } from "~/composables/usePlanLimitError.js";
+import { useVolleytrackPricingTestOverride } from "~/composables/useVolleytrackPricingTestOverride.js";
 import { confirmSuccess, confirmError } from "~/utils/sweetAlert2/swalHelper";
 import { getApiBaseUrl } from "~/utils/apiBaseUrl";
 import { useQuery } from "@vue/apollo-composable";
@@ -637,6 +660,32 @@ const runtimeConfig = useRuntimeConfig();
 const stripeKey = runtimeConfig.public.stripePublishableKey;
 const route = useRoute();
 const router = useRouter();
+
+const {
+  forcedIpCountry,
+  forcedBillingCountry,
+  isPricingOverrideActive,
+  effectivePricingIpCountry,
+  effectivePricingBillingCountry,
+} = useVolleytrackPricingTestOverride();
+
+/** Banner “Preço por região” só no desenvolvimento (NODE_ENV / Nuxt dev / APP_ENV). */
+const showVolleytrackRegionalDevBanner = computed(() => {
+  if (!isPricingOverrideActive.value) {
+    return false;
+  }
+  if (import.meta.dev) {
+    return true;
+  }
+  if (typeof process !== "undefined" && process.env?.NODE_ENV === "development") {
+    return true;
+  }
+  const appEnv = String(runtimeConfig.public?.appEnv ?? "")
+    .trim()
+    .toLowerCase();
+
+  return appEnv === "development" || appEnv === "dev";
+});
 
 // Composable para usuário
 const { user, getUserInfo, getUserEmail } = useUser();
@@ -671,7 +720,7 @@ const refreshingPlans = ref(false);
 const lifetimeCounter = ref(null);
 
 const PLANS_CACHE_KEY = "subscription_plans_cache";
-const PLANS_CACHE_VERSION = "v2";
+const PLANS_CACHE_VERSION = "v4";
 const PLANS_CACHE_TTL_MS = 1000 * 60 * 60 * 4; // 4 horas
 const PLANS_REQUEST_TIMEOUT_MS = 15000; // 15 segundos
 
@@ -792,15 +841,48 @@ const lifetimePurchaseLabel = computed(() => {
 
 // Removido: Estado do modal de troca de planos (agora redirecionamos para rota específica)
 
-// API URL (baseada em API_ENDPOINT / NUXT_PUBLIC_API_ENDPOINT)
-const getProductsUrl = () => `${getApiBaseUrl()}/v1/products`;
+const getProductsIpCountry = () => effectivePricingIpCountry.value;
+
+const getPlansStorageKey = () =>
+  `${PLANS_CACHE_KEY}:${getProductsIpCountry() ?? "default"}`;
+
+// API: lista produtos; ip_country opcional alinha preço exibido com pricing_catalog (BR vs US).
+const getProductsUrl = () => {
+  const base = `${getApiBaseUrl()}/v1/products`;
+  const ip = getProductsIpCountry();
+  if (!ip) {
+    return base;
+  }
+  return `${base}?${new URLSearchParams({ ip_country: ip }).toString()}`;
+};
 
 // URLs de redirecionamento
 const successURL = `${window.location.origin}/payment/success`;
 const cancelURL = `${window.location.origin}/payment/cancel`;
 
-// Planos exibidos baseados na periodicidade selecionada
-const getPlanPrimaryPrice = (plan) => plan?.prices?.data?.[0] || null;
+// Preço “principal” para UI: alinha com a região (BR → BRL; demais → USD), não só data[0].
+const getPlanPrimaryPrice = (plan) => {
+  const rows = plan?.prices?.data;
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return null;
+  }
+  const region = effectivePricingIpCountry.value;
+  const preferCurrency =
+    region === "BR" ? "brl" : region && region.length === 2 ? "usd" : null;
+
+  if (preferCurrency) {
+    const found = rows.find(
+      (p) =>
+        p &&
+        typeof p === "object" &&
+        String(p.currency || "").toLowerCase() === preferCurrency,
+    );
+    if (found) {
+      return found;
+    }
+  }
+  return rows[0] || null;
+};
 
 const isPlanRenderable = (plan) => {
   if (!plan || !plan.metadata?.plan_type) {
@@ -891,7 +973,7 @@ const checkoutMode = computed(() => {
   if (!selectedPlan.value) return "subscription";
 
   // Verificar se o preço é recorrente ou único
-  const priceData = selectedPlan.value.prices?.data?.[0];
+  const priceData = getPlanPrimaryPrice(selectedPlan.value);
   if (!priceData) {
     console.log(
       "⚠️ Price data não encontrado, usando subscription como padrão",
@@ -1050,7 +1132,7 @@ const loadPlansFromCache = () => {
   }
 
   try {
-    const cached = localStorage.getItem(PLANS_CACHE_KEY);
+    const cached = localStorage.getItem(getPlansStorageKey());
     if (!cached) {
       return false;
     }
@@ -1064,7 +1146,7 @@ const loadPlansFromCache = () => {
       !parsed.timestamp ||
       Date.now() - parsed.timestamp > PLANS_CACHE_TTL_MS
     ) {
-      localStorage.removeItem(PLANS_CACHE_KEY);
+      localStorage.removeItem(getPlansStorageKey());
       return false;
     }
 
@@ -1073,7 +1155,7 @@ const loadPlansFromCache = () => {
     return true;
   } catch (cacheError) {
     console.warn("⚠️ Falha ao ler cache local de planos:", cacheError);
-    localStorage.removeItem(PLANS_CACHE_KEY);
+    localStorage.removeItem(getPlansStorageKey());
     return false;
   }
 };
@@ -1085,7 +1167,7 @@ const savePlansToCache = (planList) => {
 
   try {
     localStorage.setItem(
-      PLANS_CACHE_KEY,
+      getPlansStorageKey(),
       JSON.stringify({
         version: PLANS_CACHE_VERSION,
         timestamp: Date.now(),
@@ -1103,7 +1185,7 @@ const clearPlansCache = () => {
     return;
   }
 
-  localStorage.removeItem(PLANS_CACHE_KEY);
+  localStorage.removeItem(getPlansStorageKey());
   console.log("🧹 Cache de planos limpo manualmente");
 };
 
@@ -1199,6 +1281,47 @@ const getPlanPrice = (plan) => {
 
   const formatted = formatCurrencyFromCents(priceData.unit_amount);
   return formatted ?? "—";
+};
+
+const currencyPrefixFromPlan = (plan) => {
+  const c = (getPlanPrimaryPrice(plan)?.currency || "brl").toLowerCase();
+  if (c === "brl") {
+    return "R$";
+  }
+  if (c === "usd") {
+    return "US$";
+  }
+  if (c === "eur") {
+    return "€";
+  }
+  return c.toUpperCase();
+};
+
+const formatPlanMoney = (plan) => {
+  const amt = getPlanPrice(plan);
+  if (amt === "—") {
+    return "—";
+  }
+  return `${currencyPrefixFromPlan(plan)} ${amt}`;
+};
+
+const formatYearlyAlternateMoney = (plan) => {
+  if (plan.metadata?.type !== "monthly") {
+    return "";
+  }
+  const yearlyPlan = plans.value.find(
+    (p) =>
+      p.metadata?.plan_type === plan.metadata?.plan_type &&
+      p.metadata?.type === "yearly",
+  );
+  if (yearlyPlan) {
+    return formatPlanMoney(yearlyPlan);
+  }
+  const v = getYearlyPrice(plan);
+  if (!v || v === "—") {
+    return "—";
+  }
+  return `${currencyPrefixFromPlan(plan)} ${v}`;
 };
 
 // Calcular desconto anual baseado nos preços reais
@@ -1559,7 +1682,7 @@ const isPlanActive = (plan) => {
   }
 
   const activePriceId = activePlanData.value.subscription.price_id;
-  const planPriceId = plan.prices?.data?.[0]?.id;
+  const planPriceId = getPlanPrimaryPrice(plan)?.id;
 
   const activeProduct = activePlanData.value.product || {};
   const activeProductId = activeProduct.stripe_id || activeProduct.id || null;
@@ -1754,10 +1877,11 @@ const isBetterPlan = (plan) => {
 
 // Obter valor do plano para comparação
 const getPlanValue = (plan) => {
-  if (!plan.prices?.data?.[0]?.unit_amount) {
+  const p = getPlanPrimaryPrice(plan);
+  if (!p || typeof p.unit_amount !== "number") {
     return 0;
   }
-  return plan.prices.data[0].unit_amount;
+  return p.unit_amount;
 };
 
 // Obter nível de animação baseado na diferença de valor
@@ -1953,9 +2077,9 @@ const handleSubscriptionAction = async () => {
     activePlanData.value?.subscription?.type === "one_time_payment";
 
   // Verificar se o plano selecionado é recorrente (subscription)
+  const selPrice = getPlanPrimaryPrice(selectedPlan.value);
   const selectedPlanIsRecurring =
-    selectedPlan.value?.prices?.data?.[0]?.recurring !== null &&
-    selectedPlan.value?.prices?.data?.[0]?.type !== "one_time";
+    Boolean(selPrice?.recurring) && selPrice?.type !== "one_time";
 
   console.log("🔍 isLifetimePlan:", isLifetimePlan);
   console.log("🔍 selectedPlanIsRecurring:", selectedPlanIsRecurring);
@@ -2012,7 +2136,7 @@ const handleSubscriptionAction = async () => {
 
     // Para outros casos (subscription ativa tentando comprar outra subscription),
     // redirecionar para swap
-    const priceId = selectedPlan.value.prices?.data?.[0]?.id;
+    const priceId = getPlanPrimaryPrice(selectedPlan.value)?.id;
     const customerId = activePlanData.value.customer_id;
     console.log("🔍 priceId encontrado:", priceId);
     console.log("🔍 customerId encontrado:", customerId);
@@ -2426,7 +2550,7 @@ const subscribeToPlan = async () => {
     }
 
     // Verificar se o plano tem preço válido
-    const priceId = selectedPlan.value.prices?.data?.[0]?.id;
+    const priceId = getPlanPrimaryPrice(selectedPlan.value)?.id;
     if (!priceId) {
       alert("Erro: Preço não encontrado para este plano. Tente novamente.");
       return;
@@ -2480,7 +2604,7 @@ const subscribeToPlan = async () => {
     stripeLoading.value = true;
 
     // Verificar compatibilidade do modo com o preço
-    const priceData = selectedPlan.value.prices?.data?.[0];
+    const priceData = getPlanPrimaryPrice(selectedPlan.value);
     const isRecurring = priceData?.recurring;
     const priceType = priceData?.type;
     const mode = checkoutMode.value;
@@ -2557,7 +2681,7 @@ const subscribeToPlan = async () => {
         );
         console.log("🔍 Dados do erro:", sessionResult.errorData);
 
-        const priceId = selectedPlan.value.prices?.data?.[0]?.id;
+        const priceId = getPlanPrimaryPrice(selectedPlan.value)?.id;
         if (priceId) {
           const swapUrl = `/payment/swap?price_id=${encodeURIComponent(
             priceId,
@@ -2698,6 +2822,23 @@ const loadLifetimeCounter = async () => {
   }
 };
 
+watch(
+  [() => route.query.ip_country, effectivePricingIpCountry],
+  async ([nextQuery, nextEffective], [prevQuery, prevEffective]) => {
+    if (
+      String(nextQuery ?? "") === String(prevQuery ?? "") &&
+      String(nextEffective ?? "") === String(prevEffective ?? "")
+    ) {
+      return;
+    }
+    if (!emailValidationReady.value) {
+      return;
+    }
+    clearPlansCache();
+    await loadPlans({ forceRefresh: true });
+  },
+);
+
 onMounted(async () => {
   try {
     console.log("🚀 Iniciando carregamento da página...");
@@ -2796,6 +2937,23 @@ onMounted(async () => {
   width: 100%;
   padding: 0 16px 40px;
   box-sizing: border-box;
+}
+
+.pricing-override-banner {
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: #fff7ed;
+  border: 1px solid #fdba74;
+  color: #9a3412;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+.pricing-override-banner code {
+  background: #ffedd5;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85em;
 }
 
 /* Header + botões na mesma linha (alinhado com o conteúdo abaixo) */

--- a/pages/payment/success.vue
+++ b/pages/payment/success.vue
@@ -1,37 +1,81 @@
 <template>
-  <div class="list-page-container">
+  <div
+    class="list-page-container"
+    :class="{ 'list-page-container--failure': pageFailureMode }"
+  >
     <!-- Page Header -->
     <div class="page-header">
       <div class="header-content">
         <div>
-          <h1 class="page-title">Pagamento Realizado com Sucesso!</h1>
-          <p class="page-subtitle">
-            Obrigado pela sua compra. Você receberá um email de confirmação em
+          <h1 v-if="!pageFailureMode" class="page-title">
+            Pagamento realizado com sucesso!
+          </h1>
+          <h1 v-else class="page-title page-title--failure">
+            {{ failurePageTitle }}
+          </h1>
+          <p v-if="!pageFailureMode" class="page-subtitle">
+            Obrigado pela sua compra. Você receberá um e-mail de confirmação em
             breve.
+          </p>
+          <p v-else class="page-subtitle page-subtitle--failure">
+            {{ failurePageSubtitle }}
           </p>
         </div>
       </div>
     </div>
 
     <!-- Success Card -->
-    <div class="success-card">
-      <div class="success-icon">
-        <svg
-          width="80"
-          height="80"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
+    <div
+      class="success-card"
+      :class="{ 'success-card--failure': pageFailureMode }"
+    >
+      <template v-if="!loading">
+        <div
+          v-if="pageFailureMode"
+          class="hero-icon hero-icon--failure"
+          aria-hidden="true"
         >
-          <path
-            d="M9 12L11 14L15 10M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
-            stroke="#10b981"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </div>
+          <svg
+            class="hero-failure-mark"
+            width="96"
+            height="96"
+            viewBox="0 0 96 96"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="48"
+              cy="48"
+              r="40"
+              class="hero-failure-mark__ring"
+            />
+            <path
+              class="hero-failure-mark__x"
+              d="M38 38L58 58M58 38L38 58"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </div>
+        <div v-else class="hero-icon hero-icon--success">
+          <svg
+            class="hero-success-mark"
+            width="80"
+            height="80"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M9 12L11 14L15 10M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
+              stroke="#10b981"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </div>
+      </template>
 
       <!-- Loading State -->
       <div v-if="loading" class="loading-section">
@@ -42,12 +86,16 @@
         <p v-else>Carregando detalhes da assinatura...</p>
       </div>
 
-      <!-- Error State -->
-      <div v-else-if="error" class="error-section">
-        <div class="error-icon">⚠️</div>
-        <p>Erro ao carregar detalhes: {{ error }}</p>
-        <p class="error-note">
-          Mas não se preocupe, seu pagamento foi processado com sucesso!
+      <!-- Error State (falha ao carregar sessão) -->
+      <div v-else-if="error" class="failure-panel failure-panel--load">
+        <span class="failure-panel__badge">Erro ao carregar</span>
+        <h2 class="failure-panel__title">Não foi possível exibir os detalhes</h2>
+        <p class="failure-panel__text failure-panel__text--detail">
+          {{ error }}
+        </p>
+        <p class="failure-panel__text failure-panel__text--muted">
+          Se o pagamento foi concluído no Stripe, aguarde o e-mail de confirmação
+          ou atualize esta página.
         </p>
       </div>
 
@@ -61,17 +109,50 @@
         </p>
       </div>
 
-      <!-- Sync Error State -->
-      <div v-if="syncError" class="sync-error-section">
-        <div class="sync-error-icon">⚠️</div>
-        <p>Aviso: Erro na sincronização: {{ syncError }}</p>
-        <p class="sync-error-note">
-          Seu pagamento foi processado, mas pode haver um atraso na ativação.
+      <!-- Cartão / região Brasil (422 br_declared_non_br_card) -->
+      <div
+        v-if="syncError && regionalPricingBlocked"
+        class="failure-panel failure-panel--regional"
+        role="alert"
+      >
+        <span class="failure-panel__badge">Pagamento não concluído</span>
+        <h2 class="failure-panel__title">
+          Cartão não aceito para planos com preço no Brasil
+        </h2>
+        <p class="failure-panel__text">
+          Para assinaturas em real (R$), só aceitamos cartão emitido por bancos
+          <strong>no Brasil</strong>, alinhado à política de preços regionais.
+        </p>
+        <p class="failure-panel__text failure-panel__text--muted">
+          O valor foi estornado (ou será em breve). O retorno ao cartão depende
+          do seu banco — em geral, alguns dias úteis.
+        </p>
+        <div class="failure-panel__footer">
+          <span class="failure-panel__footer-label">Precisa de ajuda?</span>
+          <a
+            class="failure-panel__link"
+            href="mailto:support@volleytrack.com"
+          >support@volleytrack.com</a>
+        </div>
+      </div>
+
+      <!-- Outros erros de sincronização -->
+      <div v-else-if="syncError" class="failure-panel failure-panel--sync">
+        <span class="failure-panel__badge failure-panel__badge--soft">Sincronização</span>
+        <h2 class="failure-panel__title">
+          Não conseguimos finalizar a atualização da sua conta
+        </h2>
+        <p class="failure-panel__text failure-panel__text--detail">
+          {{ syncError }}
+        </p>
+        <p class="failure-panel__text failure-panel__text--muted">
+          Se o pagamento consta no Stripe, a ativação pode ocorrer em instantes.
+          Caso contrário, fale com o suporte.
         </p>
       </div>
 
-      <!-- Subscription Details -->
-      <div v-else class="subscription-details">
+      <!-- Subscription Details (somente sem erro de sync nem de carregamento) -->
+      <div v-if="!loading && !error && !syncError" class="subscription-details">
         <h3>Detalhes da Assinatura</h3>
         <div class="detail-item">
           <span class="label">Status:</span>
@@ -140,9 +221,7 @@
       </div>
 
       <div class="action-buttons">
-        <NuxtLink to="/payment" class="btn btn-primary">
-          Pagamentos
-        </NuxtLink>
+        <NuxtLink to="/payment" class="btn btn-primary"> Pagamentos </NuxtLink>
         <NuxtLink to="/billing" class="btn btn-secondary">
           Faturamentos
         </NuxtLink>
@@ -159,7 +238,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, computed, onMounted } from "vue";
 import {
   getCheckoutSession,
   getCurrentSessionId,
@@ -181,6 +260,37 @@ const loading = ref(true);
 const syncLoading = ref(false);
 const error = ref(null);
 const syncError = ref(null);
+const syncErrorCode = ref(null);
+
+/** Pagamento estornado por política de região (cartão não emitido no BR). */
+const regionalPricingBlocked = computed(
+  () => syncErrorCode.value === "br_declared_non_br_card",
+);
+
+/** Falha visível após carregar (sync ou detalhes da sessão). */
+const pageFailureMode = computed(
+  () => !loading.value && (!!syncError.value || !!error.value),
+);
+
+const failurePageTitle = computed(() => {
+  if (regionalPricingBlocked.value) {
+    return "Não foi possível ativar o plano";
+  }
+  if (syncError.value) {
+    return "Não foi possível concluir a ativação";
+  }
+  return "Não foi possível carregar esta página";
+});
+
+const failurePageSubtitle = computed(() => {
+  if (regionalPricingBlocked.value) {
+    return "A cobrança foi estornada. Para preços em real (R$), use um cartão emitido no Brasil — ou entre em contato com o suporte.";
+  }
+  if (syncError.value) {
+    return "Veja os detalhes abaixo. Se o pagamento apareceu no Stripe, aguarde alguns instantes ou fale com o suporte.";
+  }
+  return "Recarregue a página ou tente novamente em alguns minutos.";
+});
 
 // Função para formatar data
 const formatDate = (date) => {
@@ -209,7 +319,7 @@ const calculateNextBilling = (sessionData) => {
   // Se for subscription, calcular baseado no período
   if (sessionData.mode === "subscription" && sessionData.subscription) {
     const currentPeriodEnd = new Date(
-      sessionData.subscription.current_period_end * 1000
+      sessionData.subscription.current_period_end * 1000,
     );
     return currentPeriodEnd;
   }
@@ -231,6 +341,7 @@ const syncSessionData = async (sessionId) => {
     console.log("🔄 Sincronizando sessão com o banco de dados:", sessionId);
     syncLoading.value = true;
     syncError.value = null;
+    syncErrorCode.value = null;
 
     const result = await syncCheckoutSession(sessionId);
 
@@ -242,7 +353,7 @@ const syncSessionData = async (sessionId) => {
       // Se temos dados de sincronização, usar eles para atualizar as informações
       if (syncData.value.subscription) {
         const nextBilling = new Date(
-          syncData.value.subscription.current_period_end
+          syncData.value.subscription.current_period_end,
         );
         nextBillingDate.value = formatDate(nextBilling);
       }
@@ -252,10 +363,12 @@ const syncSessionData = async (sessionId) => {
     } else {
       console.warn("⚠️ Erro na sincronização:", result.error);
       syncError.value = result.error;
+      syncErrorCode.value = result.errorCode ?? null;
     }
   } catch (err) {
     console.error("❌ Erro ao sincronizar sessão:", err);
     syncError.value = err.message;
+    syncErrorCode.value = err.code ?? null;
     // Não bloquear a UI por erro de sincronização
   } finally {
     syncLoading.value = false;
@@ -268,6 +381,7 @@ const loadSessionData = async () => {
     loading.value = true;
     error.value = null;
     syncError.value = null;
+    syncErrorCode.value = null;
 
     // Obter session ID da URL
     const sessionId = getCurrentSessionId();
@@ -362,6 +476,14 @@ onMounted(async () => {
   max-width: 1400px;
   margin: 0 auto;
   width: 100%;
+  transition: background 0.25s ease;
+}
+
+.list-page-container--failure {
+  background: linear-gradient(180deg, #fff5f5 0%, #fafafa 42%, #ffffff 100%);
+  min-height: 100vh;
+  padding-top: 8px;
+  padding-bottom: 48px;
 }
 
 .page-header {
@@ -383,6 +505,11 @@ onMounted(async () => {
   line-height: 1.2;
 }
 
+.page-title--failure {
+  color: #b91c1c;
+  letter-spacing: -0.02em;
+}
+
 .page-subtitle {
   font-size: 16px;
   color: #6c757d;
@@ -390,24 +517,174 @@ onMounted(async () => {
   line-height: 1.5;
 }
 
+.page-subtitle--failure {
+  color: #57534e;
+  max-width: 38rem;
+}
+
 .success-card {
   background: white;
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 40px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   text-align: center;
   max-width: 600px;
   margin: 0 auto;
+  border: 1px solid transparent;
+  transition:
+    box-shadow 0.25s ease,
+    border-color 0.25s ease;
 }
 
-.success-icon {
-  margin-bottom: 30px;
+.success-card--failure {
+  border-color: #fecaca;
+  box-shadow:
+    0 4px 24px rgba(220, 38, 38, 0.12),
+    0 0 0 1px rgba(254, 202, 202, 0.6);
+}
+
+.hero-icon {
+  margin-bottom: 28px;
   display: flex;
   justify-content: center;
+  align-items: center;
 }
 
-.success-icon svg {
-  filter: drop-shadow(0 4px 8px rgba(16, 185, 129, 0.3));
+.hero-icon--failure {
+  animation: failure-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.hero-failure-mark {
+  filter: drop-shadow(0 10px 28px rgba(220, 38, 38, 0.28));
+}
+
+.hero-failure-mark__ring {
+  fill: #fef2f2;
+  stroke: #fca5a5;
+  stroke-width: 2;
+}
+
+.hero-failure-mark__x {
+  stroke: #dc2626;
+  stroke-width: 3.2;
+}
+
+.hero-success-mark {
+  filter: drop-shadow(0 4px 12px rgba(16, 185, 129, 0.35));
+}
+
+@keyframes failure-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.88);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.failure-panel {
+  text-align: left;
+  border-radius: 14px;
+  padding: 1.35rem 1.4rem 1.25rem;
+  margin-bottom: 1.5rem;
+  border: 1px solid #fecaca;
+  background: linear-gradient(145deg, #fff1f2 0%, #fffbfb 55%, #ffffff 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+}
+
+.failure-panel--regional {
+  border-color: #f87171;
+  background: linear-gradient(160deg, #ffe4e6 0%, #fff5f5 45%, #ffffff 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    0 8px 32px rgba(185, 28, 28, 0.1);
+}
+
+.failure-panel--sync,
+.failure-panel--load {
+  border-color: #fecaca;
+}
+
+.failure-panel__badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #fef2f2;
+  background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  margin-bottom: 0.85rem;
+  box-shadow: 0 2px 8px rgba(220, 38, 38, 0.35);
+}
+
+.failure-panel__badge--soft {
+  background: linear-gradient(135deg, #991b1b 0%, #7f1d1d 100%);
+  box-shadow: 0 2px 8px rgba(127, 29, 29, 0.25);
+}
+
+.failure-panel__title {
+  margin: 0 0 0.65rem 0;
+  font-size: 1.22rem;
+  font-weight: 700;
+  color: #7f1d1d;
+  line-height: 1.35;
+  letter-spacing: -0.02em;
+}
+
+.failure-panel__text {
+  margin: 0 0 0.65rem 0;
+  font-size: 0.98rem;
+  line-height: 1.55;
+  color: #44403c;
+}
+
+.failure-panel__text--muted {
+  color: #78716c;
+  font-size: 0.92rem;
+  margin-bottom: 0;
+}
+
+.failure-panel__text--detail {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.85rem;
+  background: rgba(254, 226, 226, 0.65);
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  color: #57534e;
+  word-break: break-word;
+}
+
+.failure-panel__footer {
+  margin-top: 1.1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(252, 165, 165, 0.65);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem 0.6rem;
+  text-align: center;
+}
+
+.failure-panel__footer-label {
+  font-size: 0.9rem;
+  color: #57534e;
+}
+
+.failure-panel__link {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #7c3aed;
+  text-decoration: none;
+}
+
+.failure-panel__link:hover {
+  text-decoration: underline;
 }
 
 .subscription-details {
@@ -465,8 +742,7 @@ onMounted(async () => {
   font-weight: 700;
 }
 
-.loading-section,
-.error-section {
+.loading-section {
   text-align: center;
   padding: 20px;
   margin: 20px 0;
@@ -480,44 +756,6 @@ onMounted(async () => {
   border-radius: 50%;
   animation: spin 1s linear infinite;
   margin: 0 auto 15px;
-}
-
-.error-section {
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  border-radius: 8px;
-  color: #dc2626;
-}
-
-.error-icon {
-  font-size: 2rem;
-  margin-bottom: 10px;
-}
-
-.error-note {
-  color: #059669;
-  font-weight: 500;
-  margin-top: 10px;
-}
-
-.sync-error-section {
-  background: #fef3cd;
-  border: 1px solid #fde68a;
-  border-radius: 8px;
-  color: #92400e;
-  margin-bottom: 20px;
-}
-
-.sync-error-icon {
-  font-size: 1.5rem;
-  margin-bottom: 8px;
-}
-
-.sync-error-note {
-  color: #059669;
-  font-weight: 500;
-  margin-top: 8px;
-  font-size: 0.9rem;
 }
 
 .sync-success-section {
@@ -658,6 +896,14 @@ onMounted(async () => {
 
   .page-title {
     font-size: 24px;
+  }
+
+  .page-title--failure {
+    font-size: 22px;
+  }
+
+  .failure-panel {
+    padding: 1.1rem 1rem;
   }
 
   .success-card {

--- a/server/api/volleytrack/detect-ip-country.get.ts
+++ b/server/api/volleytrack/detect-ip-country.get.ts
@@ -1,0 +1,191 @@
+import { defineEventHandler, getHeader, getRequestIP } from "h3";
+
+/** Quando não dá para inferir país (ex.: localhost), usamos BR → listagem/preço BRL. */
+const DEFAULT_PRICING_COUNTRY = "BR";
+
+/** Timeout por tentativa (várias APIs em sequência). */
+const GEO_FETCH_MS = 3200;
+
+type GeoHit = { countryCode: string; source: string };
+
+function isPrivateOrLocalIp(ip: string): boolean {
+  const t = ip.trim().toLowerCase();
+  if (!t || t === "::1") {
+    return true;
+  }
+  if (t.startsWith("127.")) {
+    return true;
+  }
+  if (t.startsWith("10.")) {
+    return true;
+  }
+  if (t.startsWith("192.168.")) {
+    return true;
+  }
+  const m = /^172\.(\d+)\./.exec(t);
+  if (m) {
+    const n = Number.parseInt(m[1], 10);
+    if (n >= 16 && n <= 31) {
+      return true;
+    }
+  }
+  if (t.startsWith("fc") || t.startsWith("fd")) {
+    return true;
+  }
+
+  return false;
+}
+
+function normalizeCountryCode(raw: string | undefined | null): string | null {
+  if (!raw || typeof raw !== "string") {
+    return null;
+  }
+  const u = raw.trim().toUpperCase().slice(0, 2);
+  if (!/^[A-Z]{2}$/.test(u) || u === "XX") {
+    return null;
+  }
+
+  return u;
+}
+
+function fallback(source: string) {
+  return { countryCode: DEFAULT_PRICING_COUNTRY, source };
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(GEO_FETCH_MS),
+    redirect: "follow",
+  });
+  if (!res.ok) {
+    throw new Error(`http_${res.status}`);
+  }
+
+  return res.json();
+}
+
+/** https://ipwho.is/docs — sem chave. */
+async function tryIpwhoIs(ip: string): Promise<GeoHit | null> {
+  const url = `https://ipwho.is/${encodeURIComponent(ip)}`;
+  const data = (await fetchJson(url)) as {
+    success?: boolean;
+    country_code?: string;
+  };
+  if (data?.success && typeof data.country_code === "string") {
+    const cc = normalizeCountryCode(data.country_code);
+
+    return cc ? { countryCode: cc, source: "ipwhois" } : null;
+  }
+
+  return null;
+}
+
+/** https://www.geojs.io/ — sem chave. */
+async function tryGeoJs(ip: string): Promise<GeoHit | null> {
+  const url = `https://get.geojs.io/v1/ip/geo/${encodeURIComponent(ip)}.json`;
+  const data = (await fetchJson(url)) as {
+    country_code?: string;
+    country?: string;
+  };
+  const cc =
+    normalizeCountryCode(data?.country_code) ??
+    (typeof data?.country === "string" && data.country.length === 2
+      ? normalizeCountryCode(data.country)
+      : null);
+
+  return cc ? { countryCode: cc, source: "geojs" } : null;
+}
+
+/**
+ * http://ip-api.com — plano gratuito (HTTP); campos mínimos.
+ * @see https://ip-api.com/docs/
+ */
+async function tryIpApiCom(ip: string): Promise<GeoHit | null> {
+  const enc = encodeURIComponent(ip);
+  const url = `http://ip-api.com/json/${enc}?fields=status,message,countryCode`;
+  const data = (await fetchJson(url)) as {
+    status?: string;
+    countryCode?: string;
+    message?: string;
+  };
+  if (data?.status === "success" && typeof data.countryCode === "string") {
+    const cc = normalizeCountryCode(data.countryCode);
+
+    return cc ? { countryCode: cc, source: "ip-api-com" } : null;
+  }
+
+  return null;
+}
+
+/** https://ipapi.co/api/ — camada gratuita com limite de taxa. */
+async function tryIpApiCo(ip: string): Promise<GeoHit | null> {
+  const url = `https://ipapi.co/${encodeURIComponent(ip)}/json/`;
+  const data = (await fetchJson(url)) as {
+    country_code?: string;
+    error?: boolean;
+    reason?: string;
+  };
+  if (data?.error === true) {
+    return null;
+  }
+  if (typeof data?.country_code === "string") {
+    const cc = normalizeCountryCode(data.country_code);
+
+    return cc ? { countryCode: cc, source: "ipapi-co" } : null;
+  }
+
+  return null;
+}
+
+/** https://country.is/ — JSON simples, sem chave (`country` = ISO2). */
+async function tryCountryIs(ip: string): Promise<GeoHit | null> {
+  const url = `https://api.country.is/${encodeURIComponent(ip)}`;
+  const data = (await fetchJson(url)) as { country?: string };
+  if (typeof data?.country === "string") {
+    const cc = normalizeCountryCode(data.country);
+
+    return cc ? { countryCode: cc, source: "country-is" } : null;
+  }
+
+  return null;
+}
+
+/**
+ * País inferido para preços VolleyTrack quando o .env não força região.
+ * Ordem: CF-IPCountry → várias APIs gratuitas (sequencial) → BR.
+ */
+export default defineEventHandler(async (event) => {
+  const cfRaw =
+    getHeader(event, "cf-ipcountry") ?? getHeader(event, "CF-IPCountry");
+  const cf = normalizeCountryCode(cfRaw ?? null);
+  if (cf) {
+    return { countryCode: cf, source: "cf-ipcountry" };
+  }
+
+  const ip = (getRequestIP(event, { xForwardedFor: true }) ?? "").trim();
+  if (!ip || isPrivateOrLocalIp(ip)) {
+    return fallback("private-or-local-default-br");
+  }
+
+  const attempts: Array<() => Promise<GeoHit | null>> = [
+    () => tryIpwhoIs(ip),
+    () => tryGeoJs(ip),
+    () => tryCountryIs(ip),
+    () => tryIpApiCom(ip),
+    () => tryIpApiCo(ip),
+  ];
+
+  for (const run of attempts) {
+    try {
+      const hit = await run();
+      if (hit) {
+        return hit;
+      }
+    } catch {
+      /* tenta próximo provedor */
+    }
+  }
+
+  return fallback("all-providers-failed-default-br");
+});

--- a/services/stripeCheckoutService.js
+++ b/services/stripeCheckoutService.js
@@ -4,6 +4,11 @@
  */
 
 import { getApiBaseUrl } from '~/utils/apiBaseUrl'
+import {
+  getVolleytrackPricingTestHeaders,
+  getVolleytrackDeclaredPricingBodyFields,
+} from '~/utils/volleytrackPricingTestHeaders'
+import { fetchVolleytrackGeoCountryOnce } from '~/utils/volleytrackGeoIp.js'
 
 /**
  * Criar sessão de checkout no Stripe
@@ -33,6 +38,8 @@ export const createCheckoutSession = async (checkoutData) => {
       throw new Error("Token de autenticação não encontrado. Faça login novamente.");
     }
 
+    await fetchVolleytrackGeoCountryOnce()
+
     // Usar o token disponível (priorizar userToken, depois apollo)
     const authToken = token || apolloToken;
     console.log('🔍 Token que será usado:', authToken);
@@ -44,8 +51,12 @@ export const createCheckoutSession = async (checkoutData) => {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
         'Authorization': `Bearer ${authToken}`, // ✅ Adicionar token de autenticação
+        ...getVolleytrackPricingTestHeaders(),
       },
-      body: JSON.stringify(checkoutData)
+      body: JSON.stringify({
+        ...checkoutData,
+        ...getVolleytrackDeclaredPricingBodyFields(),
+      })
     })
 
     console.log('🔍 Response status:', response.status)
@@ -357,18 +368,38 @@ export const syncCheckoutSession = async (sessionId) => {
     console.log('🔍 Response status:', response.status)
 
     if (!response.ok) {
-      const errorData = await response.json()
-      console.error('❌ Erro na sincronização:', errorData)
-      
-      if (response.status === 400) {
-        throw new Error('Sessão não foi paga ou é inválida')
-      } else if (response.status === 404) {
-        throw new Error('Customer não encontrado no banco de dados')
-      } else if (response.status === 500) {
-        throw new Error(`Erro interno do servidor: ${errorData.message || 'Erro interno'}`)
-      } else {
-        throw new Error(`Erro HTTP ${response.status}: ${errorData.message || 'Erro desconhecido'}`)
+      let errorData = {}
+      try {
+        errorData = await response.json()
+      } catch (_) {
+        /* corpo vazio ou não-JSON */
       }
+      console.error('❌ Erro na sincronização:', errorData)
+
+      if (response.status === 400) {
+        throw Object.assign(new Error('Sessão não foi paga ou é inválida'), { code: null })
+      }
+      if (response.status === 404) {
+        throw Object.assign(new Error('Customer não encontrado no banco de dados'), { code: null })
+      }
+      if (response.status === 422) {
+        const code = errorData.code || null
+        const backendMsg = typeof errorData.message === 'string' ? errorData.message.trim() : ''
+        const err = new Error(backendMsg || 'Não foi possível concluir esta etapa.')
+        err.code = code
+        throw err
+      }
+      if (response.status === 500) {
+        throw Object.assign(
+          new Error(errorData.message || 'Erro interno do servidor. Tente novamente em instantes.'),
+          { code: null },
+        )
+      }
+      const fallbackMsg =
+        typeof errorData.message === 'string' && errorData.message.trim() !== ''
+          ? errorData.message.trim()
+          : 'Não foi possível sincronizar. Tente novamente ou fale com o suporte.'
+      throw Object.assign(new Error(fallbackMsg), { code: errorData.code || null })
     }
 
     const data = await response.json()
@@ -382,7 +413,8 @@ export const syncCheckoutSession = async (sessionId) => {
     console.error('❌ Erro ao sincronizar sessão:', error)
     return {
       success: false,
-      error: error.message
+      error: error.message,
+      errorCode: error.code ?? null,
     }
   }
 }

--- a/utils/volleytrackGeoIp.js
+++ b/utils/volleytrackGeoIp.js
@@ -1,0 +1,81 @@
+/**
+ * País inferido por IP (rota Nitro /api/volleytrack/detect-ip-country).
+ * Usado quando NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_* estão vazios.
+ * Se a API falhar ou não houver ambiente browser, assume **BR** (BRL).
+ */
+
+const DEFAULT_GEO_COUNTRY = "BR";
+
+let geoResolved = false;
+let geoCode = /** @type {string|null} */ (null);
+let inflight = /** @type {Promise<string|null>|null} */ (null);
+
+function normalize2(v) {
+  const s = String(v ?? "")
+    .trim()
+    .toUpperCase();
+  return s.length >= 2 ? s.slice(0, 2) : null;
+}
+
+/**
+ * @param {typeof import('ofetch').$fetch} [$fetch]
+ * @returns {Promise<string|null>}
+ */
+export async function fetchVolleytrackGeoCountryOnce($fetch) {
+  if (geoResolved) {
+    return geoCode;
+  }
+  if (inflight) {
+    return inflight;
+  }
+
+  inflight = (async () => {
+    try {
+      let payload;
+      if (typeof $fetch === "function") {
+        payload = await $fetch("/api/volleytrack/detect-ip-country");
+      } else if (typeof window !== "undefined" && window.location?.origin) {
+        const res = await fetch(
+          `${window.location.origin}/api/volleytrack/detect-ip-country`,
+          { credentials: "same-origin" },
+        );
+        payload = await res.json();
+      } else {
+        geoResolved = true;
+        geoCode = DEFAULT_GEO_COUNTRY;
+
+        return geoCode;
+      }
+      const cc = normalize2(payload?.countryCode) ?? DEFAULT_GEO_COUNTRY;
+      geoResolved = true;
+      geoCode = cc;
+
+      return geoCode;
+    } catch {
+      geoResolved = true;
+      geoCode = DEFAULT_GEO_COUNTRY;
+
+      return geoCode;
+    } finally {
+      inflight = null;
+    }
+  })();
+
+  return inflight;
+}
+
+/** Código ISO2 após lookup; antes do primeiro fetch retorna null. Depois do fetch, nunca null (fallback BR). */
+export function getVolleytrackGeoCountrySync() {
+  if (!geoResolved) {
+    return null;
+  }
+
+  return geoCode ?? DEFAULT_GEO_COUNTRY;
+}
+
+/** Para testes ou hidratação: fixar cache manualmente. */
+export function resetVolleytrackGeoCacheForTests() {
+  geoResolved = false;
+  geoCode = null;
+  inflight = null;
+}

--- a/utils/volleytrackPricingTestHeaders.js
+++ b/utils/volleytrackPricingTestHeaders.js
@@ -1,0 +1,68 @@
+import { getVolleytrackGeoCountrySync } from "./volleytrackGeoIp.js";
+
+/**
+ * Headers opcionais para o backend (ex.: checkout) refletirem países “simulados” no metadata Stripe.
+ * Mesma prioridade que getApiBaseUrl: window.__NUXT__ no cliente, senão env em build.
+ * Se não houver override no .env, usa país inferido por IP (após fetchVolleytrackGeoCountryOnce).
+ */
+function resolveVolleytrackForcedCountries() {
+  const norm = (v) => {
+    const s = String(v ?? "").trim().toUpperCase();
+    return s.length >= 2 ? s.slice(0, 2) : "";
+  };
+
+  let ipCountry = "";
+  let billingCountry = "";
+
+  if (typeof window !== "undefined") {
+    const nuxt = window.__NUXT__;
+    const pub = nuxt?.config?.public || nuxt?.runtimeConfig?.public || {};
+    ipCountry = norm(pub.volleytrackForcePricingIpCountry);
+    billingCountry = norm(pub.volleytrackForcePricingBillingCountry);
+  }
+
+  if (!ipCountry) {
+    ipCountry = norm(process.env.NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_IP_COUNTRY);
+  }
+  if (!billingCountry) {
+    billingCountry = norm(
+      process.env.NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_BILLING_COUNTRY,
+    );
+  }
+
+  const geo = getVolleytrackGeoCountrySync();
+  const geoNorm = geo ? norm(geo) : "";
+  if (!ipCountry && geoNorm) {
+    ipCountry = geoNorm;
+  }
+  if (!billingCountry && geoNorm) {
+    billingCountry = geoNorm;
+  }
+
+  return { ipCountry, billingCountry };
+}
+
+export function getVolleytrackPricingTestHeaders() {
+  const { ipCountry, billingCountry } = resolveVolleytrackForcedCountries();
+  const headers = {};
+  if (ipCountry) {
+    headers["X-Volleytrack-Test-Ip-Country"] = ipCountry;
+  }
+  if (billingCountry) {
+    headers["X-Volleytrack-Test-Billing-Country"] = billingCountry;
+  }
+  return headers;
+}
+
+/** Campos JSON opcionais (fallback se headers forem bloqueados ou ausentes no request). */
+export function getVolleytrackDeclaredPricingBodyFields() {
+  const { ipCountry, billingCountry } = resolveVolleytrackForcedCountries();
+  const out = {};
+  if (ipCountry) {
+    out.declared_ip_country = ipCountry;
+  }
+  if (billingCountry) {
+    out.declared_billing_country = billingCountry;
+  }
+  return out;
+}


### PR DESCRIPTION
### Jira

[VT-120](https://zorensoftware.atlassian.net/browse/VT-120)

### O que?

Primeira etapa de conformidade com a LGPD: política de privacidade pública do VolleyTrack e integração nos pontos de contato do produto.

**Landing (`LandingPage-FrontEnd-VoleiClub`)**

- Nova página pública `/privacy-policy` com texto em português (10 seções: dados coletados, finalidade, base legal, segurança/AWS, compartilhamento, retenção, direitos do titular, contato `support@volleytrack.com`, data de atualização Maio/2026).
- Listas com marcadores visíveis e itens iniciando em maiúscula.
- Link no menu (navbar + sidebar mobile), footer e entrada no `sitemap.xml`.
- Chave i18n `footer_privacy_policy` nos 7 idiomas (rótulo do link; conteúdo da política permanece em pt-BR nesta entrega).
- Correção do link **Sobre** no footer/menu: de `/sobre` (inexistente) para scroll até `#about-section` na home, com função `routeAbout` (mesmo padrão de Planos/FAQ).
- `id="about-section"` na seção correspondente da landing.

**App SaaS (`VoleiClub-Front`)**

- Componente `ZLegalLinks` com link externo para a URL canônica da política (nova aba).
- Exibição no layout `default` (sidebar + rodapé da área principal) e no layout `login` (inclui set-password).
- Variável `NUXT_PUBLIC_PRIVACY_POLICY_URL` documentada no `.env.example`, com fallback em `nuxt.config.ts` para `https://volleytrack.com/privacy-policy` quando a env estiver vazia ou ausente.

> Esta entrega não altera backend Laravel, banner de cookies, termos de uso nem fluxo de consentimento versionado.

### Por quê?

- Sair de um estado “sem política visível” e dar transparência mínima sobre tratamento de dados (requisito inicial de LGPD).
- Centralizar o documento legal na **landing** (`volleytrack.com`), onde o usuário se cadastra, evitando duplicar texto no app multi-tenant.
- Garantir que usuários logados e visitantes do login ainda encontrem o link sem depender só do site de marketing.
- Corrigir navegação quebrada do **Sobre** e melhorar descoberta da política no menu/footer.

### Como?

**Arquitetura**

- URL canônica: `https://volleytrack.com/privacy-policy`.
- App apenas referencia essa URL via `config.public.privacyPolicyUrl` (sem página duplicada no SPA do tenant).

**Decisões técnicas**

| Tema | Decisão |
|------|---------|
| Onde hospedar a política | Landing (pública por padrão, footer legal, SEO/sitemap) |
| App | Links externos (`target="_blank"`) em `ZLegalLinks` |
| Auto-import Nuxt | `pathPrefix: true` não resolve `ZLegalLinks` — import explícito nos layouts `default` e `login` |
| `privacyPolicyUrl` | IIFE no `nuxt.config.ts`: lê `process.env` + `dotenv` parsed, ignora string vazia, fallback fixo; `ZLegalLinks` repete fallback no `computed` por segurança |
| Dev local | `.env.example` sugere `http://localhost:3001/privacy-policy` |
| Listas na política | `::before` com `•` (reset do Vuestic removia `list-style` nativo) |
| Sobre | `routeAbout` + `querySelector('.about-section')` + `scrollIntoView`, com redirect para `/` quando fora da home |

**Arquivos principais**

| Repositório | Criados | Alterados |
|-------------|---------|-----------|
| Landing | `pages/privacy-policy/index.vue` | `layouts/default.vue`, `pages/index.vue`, `public/sitemap.xml`, `locales/*.json` |
| App | `components/organisms/Footer/ZLegalLinks.vue` | `layouts/default.vue`, `layouts/login.vue`, `nuxt.config.ts`, `.env.example` |

### Capturas de tela

_Adicionar antes do merge:_

1. Landing — `/privacy-policy` (desktop e mobile).
2. Landing — link no menu e no footer.
3. Landing — clique em **Sobre** a partir de `/faq` ou `/privacy-policy` (scroll na home).
4. App — link na sidebar, rodapé do conteúdo e tela de login.
5. App — link abrindo a landing em nova aba (validar URL com e sem `NUXT_PUBLIC_PRIVACY_POLICY_URL` no `.env`).

### Verificações

- [ ] Landing: `/privacy-policy` acessível sem login.
- [ ] Landing: footer e navbar com link; sitemap contém a URL.
- [ ] Landing: **Sobre** rola até a seção na home a partir de outras rotas.
- [ ] App: `ZLegalLinks` visível em `default` e `login`.
- [ ] App: com `.env` vazio/comentado, link usa `https://volleytrack.com/privacy-policy`.
- [ ] App: com `NUXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost:3001/privacy-policy`, link aponta para a landing local.
- [ ] Lembrete: Ajustar o `composer.json` com a versão — **N/A** (somente frontends; sem mudança no backend).

### Test plan rápido

```bash
# Landing (porta 3001)
cd LandingPage-FrontEnd-VoleiClub && pnpm dev

# App (porta 3000)
cd VoleiClub-Front && npm run dev
```


[VT-120]: https://zorensoftware.atlassian.net/browse/VT-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ