### PR TITLE
feat(legal-links): add terms of use link and update footer component - VT-121

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,6 @@ NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_BILLING_COUNTRY=
 # URL canônica da política de privacidade (landing). Em dev local: http://localhost:3001/privacy-policy
 # Deixe em branco ou comente para usar o padrão (https://volleytrack.com/privacy-policy).
 NUXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost:3001/privacy-policy
+
+# URL canônica dos termos de uso (landing). Em dev local: http://localhost:3001/terms-of-use
+NUXT_PUBLIC_TERMS_OF_USE_URL=http://localhost:3001/terms-of-use

--- a/components/organisms/Footer/ZLegalLinks.vue
+++ b/components/organisms/Footer/ZLegalLinks.vue
@@ -1,13 +1,24 @@
 <template>
-  <a
-    :href="privacyPolicyUrl"
-    class="legal-links__anchor"
-    :class="`legal-links__anchor--${variant}`"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Política de Privacidade
-  </a>
+  <div class="legal-links" :class="`legal-links--${variant}`">
+    <a
+      :href="privacyPolicyUrl"
+      class="legal-links__anchor"
+      :class="`legal-links__anchor--${variant}`"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Política de Privacidade
+    </a>
+    <a
+      :href="termsOfUseUrl"
+      class="legal-links__anchor"
+      :class="`legal-links__anchor--${variant}`"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Termos de Uso
+    </a>
+  </div>
 </template>
 
 <script setup>
@@ -20,13 +31,26 @@ defineProps({
 });
 
 const config = useRuntimeConfig();
+
 const privacyPolicyUrl = computed(() => {
   const url = String(config.public.privacyPolicyUrl ?? "").trim();
   return url || "https://volleytrack.com/privacy-policy";
 });
+
+const termsOfUseUrl = computed(() => {
+  const url = String(config.public.termsOfUseUrl ?? "").trim();
+  return url || "https://volleytrack.com/terms-of-use";
+});
 </script>
 
 <style scoped>
+.legal-links {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
 .legal-links__anchor {
   font-size: 12px;
   text-decoration: none;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -109,6 +109,14 @@ export default defineNuxtConfig({
         const trimmed = String(raw).trim()
         return trimmed || 'https://volleytrack.com/privacy-policy'
       })(),
+      termsOfUseUrl: (() => {
+        const raw =
+          process.env.NUXT_PUBLIC_TERMS_OF_USE_URL ||
+          env.NUXT_PUBLIC_TERMS_OF_USE_URL ||
+          ''
+        const trimmed = String(raw).trim()
+        return trimmed || 'https://volleytrack.com/terms-of-use'
+      })(),
     }
   },
   vuestic: {


### PR DESCRIPTION
### Jira

[VT-121](https://zorensoftware.atlassian.net/browse/VT-121)

### O que?

Integração dos **Termos de Uso** no app SaaS VolleyTrack, apontando para a página canônica na landing (`volleytrack.com/terms-of-use`).

- Segundo link **Termos de Uso** no componente `ZLegalLinks` (abre em nova aba).
- Variável de ambiente `NUXT_PUBLIC_TERMS_OF_USE_URL` com fallback para produção.
- Exibição nos layouts `default` (sidebar + rodapé do conteúdo) e `login` (já usam `ZLegalLinks`).

> O conteúdo legal permanece na **landing** — esta PR não duplica a página no app.

### Por quê?

- Usuários logados e visitantes da tela de login precisam acessar os termos sem depender só do site de marketing.
- Manter **uma única fonte de verdade** (mesma abordagem da Política de Privacidade), evitando textos divergentes entre subdomínios do tenant.
- Permitir URL configurável em desenvolvimento (`localhost:3001`).

### Como?

**Configuração**

- `nuxt.config.ts`: `public.termsOfUseUrl` lê `NUXT_PUBLIC_TERMS_OF_USE_URL` e `env` parseado; ignora string vazia; fallback `https://volleytrack.com/terms-of-use` (mesmo padrão de `privacyPolicyUrl`).

**Componente**

- `components/organisms/Footer/ZLegalLinks.vue`:
  - Container em coluna com dois links: Política de Privacidade + Termos de Uso.
  - `target="_blank"` e `rel="noopener noreferrer"`.
  - Textos em português (consistente com o link de privacidade já existente).

**Ambiente**

- `.env.example` documenta `NUXT_PUBLIC_TERMS_OF_USE_URL=http://localhost:3001/terms-of-use`.

**Arquivos alterados**

| Arquivo |
|---------|
| `components/organisms/Footer/ZLegalLinks.vue` |
| `nuxt.config.ts` |
| `.env.example` |

Layouts `default.vue` e `login.vue` **não precisam de alteração** — já importam e renderizam `ZLegalLinks`.

### Capturas de tela

<img width="1038" height="2011" alt="image" src="https://github.com/user-attachments/assets/88dffc90-308e-41c3-a8d9-4f2db0072c88" />

<img width="1891" height="1985" alt="image" src="https://github.com/user-attachments/assets/489c7ac1-3e78-4266-b4d4-c283631e76cf" />

<img width="3237" height="1959" alt="image" src="https://github.com/user-attachments/assets/e63c47bb-01a9-4022-b22a-d370945daa2c" />

<img width="2845" height="1961" alt="image" src="https://github.com/user-attachments/assets/59f5ade8-875c-4b0a-8c47-2793f2a9a85b" />


_Adicionar antes do merge:_

1. Sidebar do app com **Política de Privacidade** e **Termos de Uso**.
2. Rodapé da área principal (mesmos links).
3. Tela de login com os dois links no rodapé.
4. Clique em **Termos de Uso** abrindo `https://volleytrack.com/terms-of-use` (ou URL do `.env` em dev).

### Verificações

- [x] Links visíveis na sidebar (expandida), rodapé do conteúdo e login.
- [x] Com `.env` vazio/comentado, Termos aponta para `https://volleytrack.com/terms-of-use`.
- [x] Com `NUXT_PUBLIC_TERMS_OF_USE_URL=http://localhost:3001/terms-of-use`, abre a landing local.
- [x] Link de Política de Privacidade continua funcionando.
- [x] Lembrete: Ajustar o `composer.json` com a versão — **N/A** (frontend Nuxt; sem backend PHP).

### Test plan rápido

```bash
cd VoleiClub-Front
# .env
NUXT_PUBLIC_TERMS_OF_USE_URL=http://localhost:3001/terms-of-use
NUXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost:3001/privacy-policy

npm run dev
# Verificar sidebar, login e rodapé do conteúdo
```


[VT-121]: https://zorensoftware.atlassian.net/browse/VT-121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ