### PR TITLE
feat(LGPD): termos de aceite por usuário - VT-122

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,6 @@ NUXT_PUBLIC_VOLLEYTRACK_FORCE_PRICING_BILLING_COUNTRY=
 # URL canônica da política de privacidade (landing). Em dev local: http://localhost:3001/privacy-policy
 # Deixe em branco ou comente para usar o padrão (https://volleytrack.com/privacy-policy).
 NUXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost:3001/privacy-policy
+
+# URL canônica dos termos de uso (landing). Em dev local: http://localhost:3001/terms-of-use
+NUXT_PUBLIC_TERMS_OF_USE_URL=http://localhost:3001/terms-of-use

--- a/components/atoms/Modal/ZModal.vue
+++ b/components/atoms/Modal/ZModal.vue
@@ -2,15 +2,15 @@
   <VaModal
     v-bind="$attrs"
     :model-value="modelValue"
-    @update:modelValue="$emit('update:modelValue', $event)"
+    @update:modelValue="onModelUpdate"
     :ok-text="okText"
     :cancel-text="cancelText"
     :ok-disabled="okDisabled"
     @ok="$emit('ok')"
     @cancel="$emit('cancel')"
     size="medium"
-    close-button
-    :no-dismiss="false"
+    :close-button="!hideCloseButton"
+    :no-dismiss="persistent"
     class="z-modal"
     style="z-index: 1001"
   >
@@ -48,9 +48,25 @@ export default {
       type: Boolean,
       default: false,
     },
+    persistent: {
+      type: Boolean,
+      default: false,
+    },
+    hideCloseButton: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ["update:modelValue", "ok", "cancel"],
-  inheritAttrs: false, // 🔥 necessário para evitar duplicação com `v-bind="$attrs"`
+  inheritAttrs: false,
+  methods: {
+    onModelUpdate(value) {
+      if (this.persistent && value === false) {
+        return;
+      }
+      this.$emit("update:modelValue", value);
+    },
+  },
 };
 </script>
 

--- a/components/molecules/List/ZListItemsUser.vue
+++ b/components/molecules/List/ZListItemsUser.vue
@@ -43,6 +43,7 @@ export default {
       onLogout();
       localStorage.removeItem("user");
       localStorage.removeItem("userToken");
+      useTermsAcceptance().reset();
       this.$router.push("/login");
     },
 

--- a/components/organisms/Footer/ZLegalLinks.vue
+++ b/components/organisms/Footer/ZLegalLinks.vue
@@ -1,13 +1,24 @@
 <template>
-  <a
-    :href="privacyPolicyUrl"
-    class="legal-links__anchor"
-    :class="`legal-links__anchor--${variant}`"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Política de Privacidade
-  </a>
+  <div class="legal-links" :class="`legal-links--${variant}`">
+    <a
+      :href="privacyPolicyUrl"
+      class="legal-links__anchor"
+      :class="`legal-links__anchor--${variant}`"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Política de Privacidade
+    </a>
+    <a
+      :href="termsOfUseUrl"
+      class="legal-links__anchor"
+      :class="`legal-links__anchor--${variant}`"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Termos de Uso
+    </a>
+  </div>
 </template>
 
 <script setup>
@@ -20,13 +31,26 @@ defineProps({
 });
 
 const config = useRuntimeConfig();
+
 const privacyPolicyUrl = computed(() => {
   const url = String(config.public.privacyPolicyUrl ?? "").trim();
   return url || "https://volleytrack.com/privacy-policy";
 });
+
+const termsOfUseUrl = computed(() => {
+  const url = String(config.public.termsOfUseUrl ?? "").trim();
+  return url || "https://volleytrack.com/terms-of-use";
+});
 </script>
 
 <style scoped>
+.legal-links {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
 .legal-links__anchor {
   font-size: 12px;
   text-decoration: none;

--- a/components/organisms/Forms/SetPassword/ZSetPasswordForm.vue
+++ b/components/organisms/Forms/SetPassword/ZSetPasswordForm.vue
@@ -32,9 +32,20 @@
         </div>
       </div>
       <div class="row justify-center px-3 pb-3">
+        <label class="set-password-terms">
+          <input v-model="termsAccepted" type="checkbox" />
+          <span>
+            Li e concordo com os
+            <a :href="termsOfUseUrl" target="_blank" rel="noopener noreferrer">Termos de Uso</a>
+            e
+            <a :href="privacyPolicyUrl" target="_blank" rel="noopener noreferrer">Política de Privacidade</a>
+          </span>
+        </label>
+      </div>
+      <div class="row justify-center px-3 pb-3">
         <ZButton
           :block="true"
-          :disabled="buttonDisabled"
+          :disabled="buttonDisabled || !termsAccepted"
           :loading="loading"
           color="primary"
           @click="registerPassword"
@@ -76,7 +87,19 @@ export default {
       email: this.$route.params.email,
       password: "",
       buttonDisabled: true,
+      termsAccepted: false,
     };
+  },
+
+  computed: {
+    privacyPolicyUrl() {
+      const url = String(this.$config?.public?.privacyPolicyUrl ?? "").trim();
+      return url || "https://volleytrack.com/privacy-policy";
+    },
+    termsOfUseUrl() {
+      const url = String(this.$config?.public?.termsOfUseUrl ?? "").trim();
+      return url || "https://volleytrack.com/terms-of-use";
+    },
   },
 
   methods: {
@@ -92,6 +115,7 @@ export default {
           password: this.password,
           passwordConfirmation: this.password,
           token: this.$route.params.token,
+          termsAccepted: true,
         };
 
         const { mutate } = await useMutation(query, { variables });
@@ -125,3 +149,20 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.set-password-terms {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 1.45;
+  color: #374151;
+  max-width: 420px;
+}
+
+.set-password-terms a {
+  color: #ff4e1b;
+  text-decoration: underline;
+}
+</style>

--- a/components/organisms/Modal/ZTermsAcceptanceModal.vue
+++ b/components/organisms/Modal/ZTermsAcceptanceModal.vue
@@ -1,0 +1,91 @@
+<template>
+  <ZModal
+    :model-value="isModalOpen"
+    title="Aceite dos Termos"
+    ok-text="Confirmar aceite"
+    :ok-disabled="!hasAgreed || isSubmitting"
+    :persistent="true"
+    :hide-close-button="true"
+    class="terms-acceptance-modal"
+    @ok="onConfirm"
+  >
+    <p class="terms-acceptance-modal__intro">
+      Para continuar usando o VolleyTrack, é necessário aceitar a versão atual dos
+      Termos de Uso e da Política de Privacidade.
+    </p>
+
+    <div class="terms-acceptance-modal__links">
+      <ZLegalLinks variant="light" />
+    </div>
+
+    <label class="terms-acceptance-modal__checkbox">
+      <input v-model="hasAgreed" type="checkbox" class="terms-acceptance-modal__input" />
+      <span>
+        Li e concordo com os Termos de Uso e Política de Privacidade
+      </span>
+    </label>
+  </ZModal>
+</template>
+
+<script setup>
+import ZModal from "~/components/atoms/Modal/ZModal.vue";
+import ZLegalLinks from "~/components/organisms/Footer/ZLegalLinks.vue";
+import { useTermsAcceptance } from "~/composables/useTermsAcceptance";
+import { confirmError } from "~/utils/sweetAlert2/swalHelper";
+
+const { isModalOpen, isSubmitting, acceptTerms } = useTermsAcceptance();
+const hasAgreed = ref(false);
+
+watch(isModalOpen, (open) => {
+  if (open) {
+    hasAgreed.value = false;
+  }
+});
+
+const onConfirm = async () => {
+  if (!hasAgreed.value || isSubmitting.value) {
+    return;
+  }
+
+  try {
+    await acceptTerms();
+  } catch {
+    confirmError(
+      "Não foi possível registrar o aceite. Tente novamente.",
+      () => {}
+    );
+  }
+};
+</script>
+
+<style scoped>
+.terms-acceptance-modal__intro {
+  margin: 0 0 16px;
+  color: #374151;
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.terms-acceptance-modal__links {
+  margin-bottom: 20px;
+}
+
+.terms-acceptance-modal__links :deep(.legal-links) {
+  align-items: flex-start;
+}
+
+.terms-acceptance-modal__checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+  color: #111827;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.terms-acceptance-modal__input {
+  margin-top: 3px;
+  flex-shrink: 0;
+}
+</style>

--- a/composables/useTermsAcceptance.js
+++ b/composables/useTermsAcceptance.js
@@ -1,0 +1,113 @@
+import { ref } from "vue";
+import ACCEPT_TERMS from "~/graphql/terms/mutation/acceptTerms.graphql";
+import ME from "~/graphql/user/query/me.graphql";
+
+const isModalOpen = ref(false);
+const isSubmitting = ref(false);
+
+export const useTermsAcceptance = () => {
+  const syncFromUser = (user) => {
+    if (!user?.termsAcceptanceStatus) {
+      return;
+    }
+
+    if (user.termsAcceptanceStatus.required) {
+      isModalOpen.value = true;
+    } else {
+      isModalOpen.value = false;
+    }
+  };
+
+  const openModal = () => {
+    isModalOpen.value = true;
+  };
+
+  const closeModal = () => {
+    isModalOpen.value = false;
+  };
+
+  const reset = () => {
+    isModalOpen.value = false;
+    isSubmitting.value = false;
+  };
+
+  const handleGraphQLError = (error) => {
+    const graphQLErrors = error?.graphQLErrors || error?.graphqlErrors;
+
+    if (!Array.isArray(graphQLErrors)) {
+      return false;
+    }
+
+    const hasTermsError = graphQLErrors.some(
+      (err) =>
+        err?.extensions?.code === "TERMS_ACCEPTANCE_REQUIRED" ||
+        (typeof err?.message === "string" &&
+          err.message.includes("Termos de Uso"))
+    );
+
+    if (hasTermsError) {
+      isModalOpen.value = true;
+      return true;
+    }
+
+    return false;
+  };
+
+  const refreshMe = async () => {
+    const query = gql`
+      ${ME}
+    `;
+    const { data } = await useAsyncQuery(query, {});
+
+    if (data?.value?.me) {
+      const user = data.value.me;
+      localStorage.setItem("user", JSON.stringify(user));
+      syncFromUser(user);
+      return user;
+    }
+
+    return null;
+  };
+
+  const acceptTerms = async () => {
+    if (isSubmitting.value) {
+      return false;
+    }
+
+    isSubmitting.value = true;
+
+    try {
+      const mutation = gql`
+        ${ACCEPT_TERMS}
+      `;
+      const { mutate } = useMutation(mutation);
+      await mutate();
+
+      await refreshMe();
+      isModalOpen.value = false;
+
+      if (import.meta.client) {
+        window.location.reload();
+      }
+
+      return true;
+    } catch (error) {
+      console.error("Erro ao registrar aceite dos termos:", error);
+      throw error;
+    } finally {
+      isSubmitting.value = false;
+    }
+  };
+
+  return {
+    isModalOpen,
+    isSubmitting,
+    syncFromUser,
+    openModal,
+    closeModal,
+    reset,
+    handleGraphQLError,
+    acceptTerms,
+    refreshMe,
+  };
+};

--- a/graphql/terms/mutation/acceptTerms.graphql
+++ b/graphql/terms/mutation/acceptTerms.graphql
@@ -1,0 +1,8 @@
+mutation acceptTerms {
+  acceptTerms {
+    id
+    termsVersion
+    termsAcceptedAt
+    termsAcceptedIp
+  }
+}

--- a/graphql/user/mutation/userSetPassword.graphql
+++ b/graphql/user/mutation/userSetPassword.graphql
@@ -4,13 +4,14 @@ mutation userSetPassword(
   $token: String!
   $password: String!
   $passwordConfirmation: String!
-
+  $termsAccepted: Boolean!
 ) {
   userSetPassword(
     email: $email
     token: $token
     password: $password
     passwordConfirmation: $passwordConfirmation
+    termsAccepted: $termsAccepted
   ) {
     id
     name

--- a/graphql/user/query/me.graphql
+++ b/graphql/user/query/me.graphql
@@ -14,5 +14,11 @@ query me {
       name
     }
     emailVerifiedAt
+    termsAcceptanceStatus {
+      required
+      currentVersion
+      acceptedVersion
+      acceptedAt
+    }
   }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -222,6 +222,7 @@
         </footer>
       </div>
     </div>
+    <ZTermsAcceptanceModal />
   </div>
 </template>
 
@@ -229,6 +230,8 @@
 import ZListItemsNotification from "~/components/organisms/List/Notification/ZListItemsNotification.vue";
 import ZListItemsUser from "~/components/molecules/List/ZListItemsUser.vue";
 import ZLegalLinks from "~/components/organisms/Footer/ZLegalLinks.vue";
+import ZTermsAcceptanceModal from "~/components/organisms/Modal/ZTermsAcceptanceModal.vue";
+import { useTermsAcceptance } from "~/composables/useTermsAcceptance";
 import NOTIFICATIONSTOTAL from "~/graphql/notification/query/notificationsTotal.graphql";
 import ME from "~/graphql/user/query/me.graphql";
 import { getActivePlan } from "~/services/stripeCheckoutService.js";
@@ -239,6 +242,7 @@ export default {
     ZListItemsNotification,
     ZListItemsUser,
     ZLegalLinks,
+    ZTermsAcceptanceModal,
   },
   data() {
     return {
@@ -661,6 +665,7 @@ export default {
               roles: value.me.roles || [],
             };
             localStorage.setItem("user", JSON.stringify(this.user));
+            useTermsAcceptance().syncFromUser(value.me);
             return;
           }
         } catch (e) {

--- a/middleware/apollo.global.ts
+++ b/middleware/apollo.global.ts
@@ -2,6 +2,7 @@ import { defineNuxtPlugin } from '#app'
 import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client/core'
 import { setContext } from '@apollo/client/link/context'
 import { onError } from '@apollo/client/link/error'
+import { useTermsAcceptance } from '~/composables/useTermsAcceptance'
 
 export default defineNuxtPlugin(nuxtAppMain => {
   
@@ -35,7 +36,13 @@ export default defineNuxtPlugin(nuxtAppMain => {
   // NOTE - Adicionar link de tratamento de erro
   const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) => {
     if (graphQLErrors) {
+      const { handleGraphQLError: handleTermsError } = useTermsAcceptance()
+
       for (let err of graphQLErrors) {
+        if (handleTermsError({ graphQLErrors: [err] })) {
+          continue
+        }
+
         console.log(err.message)
         if (err.message === 'Unauthenticated.') {
           localStorage.removeItem("user");

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -109,6 +109,14 @@ export default defineNuxtConfig({
         const trimmed = String(raw).trim()
         return trimmed || 'https://volleytrack.com/privacy-policy'
       })(),
+      termsOfUseUrl: (() => {
+        const raw =
+          process.env.NUXT_PUBLIC_TERMS_OF_USE_URL ||
+          env.NUXT_PUBLIC_TERMS_OF_USE_URL ||
+          ''
+        const trimmed = String(raw).trim()
+        return trimmed || 'https://volleytrack.com/terms-of-use'
+      })(),
     }
   },
   vuestic: {

--- a/plugins/termsAcceptanceHandler.client.ts
+++ b/plugins/termsAcceptanceHandler.client.ts
@@ -1,0 +1,12 @@
+import { defineNuxtPlugin } from "#app";
+import { useTermsAcceptance } from "~/composables/useTermsAcceptance";
+
+export default defineNuxtPlugin(() => {
+  const { handleGraphQLError } = useTermsAcceptance();
+
+  return {
+    provide: {
+      handleTermsAcceptanceError: handleGraphQLError,
+    },
+  };
+});


### PR DESCRIPTION
<!--
Título sugerido (prlint):
feat(terms): modal global de aceite de termos e privacidade - VT-122

Branch sugerida:
feature/vt122-terms-acceptance
-->

### Jira

[VT-122](https://zorensoftware.atlassian.net/browse/VT-122)

### O que?

Implementa no app Nuxt a experiência de aceite obrigatório de **Termos de Uso** e **Política de Privacidade**, integrada à API GraphQL do backend (VT-122).

Principais entregas:

- Modal global `ZTermsAcceptanceModal` no layout autenticado (`default.vue`).
- Composable `useTermsAcceptance` (estado do modal, sync via `me`, mutation `acceptTerms`, tratamento de erro `TERMS_ACCEPTANCE_REQUIRED`).
- Plugin Apollo (`termsAcceptanceHandler.client.ts`) e middleware (`apollo.global.ts`) para abrir o modal quando a API bloquear por termos pendentes.
- Campo `termsAcceptanceStatus` na query `me`; mutation `acceptTerms`.
- Checkbox e envio de `termsAccepted` em `ZSetPasswordForm` (`userSetPassword`).
- URLs dos documentos legais via `runtimeConfig` (`termsOfUseUrl`, `privacyPolicyUrl`) apontando para a landing.
- Links legais reutilizados em `ZLegalLinks` / footer onde aplicável.

> **Dependência:** requer o backend com middleware, mutations e campos GraphQL de termos já publicados (PR correspondente no repositório VoleiClub).

### Por quê?

Usuários logados precisam ver e aceitar a versão vigente dos termos antes de usar o sistema. Se a versão mudar no backend, o modal deve reaparecer até novo aceite — sem depender só de checagem manual em cada tela.

O front não versiona os textos legais; apenas exibe links para a landing e envia o aceite à API.

### Como?

**Fluxo principal**

1. Após login, `me` traz `termsAcceptanceStatus.required`.
2. Se `required === true`, o composable abre `ZTermsAcceptanceModal`.
3. Usuário marca o checkbox e confirma → `acceptTerms` → `window.location.reload()` para reidratar sessão/estado.
4. Se qualquer request GraphQL retornar `TERMS_ACCEPTANCE_REQUIRED`, o handler Apollo abre o mesmo modal.

**Arquivos principais**

| Área | Arquivo |
|------|---------|
| UI | `components/organisms/Modal/ZTermsAcceptanceModal.vue` |
| Estado / API | `composables/useTermsAcceptance.js` |
| Layout | `layouts/default.vue` |
| Apollo | `plugins/termsAcceptanceHandler.client.ts`, `middleware/apollo.global.ts` |
| GraphQL | `graphql/terms/mutation/acceptTerms.graphql`, `graphql/user/query/me.graphql` |
| Senha inicial | `components/organisms/Forms/SetPassword/ZSetPasswordForm.vue` |
| Config | `nuxt.config.ts`, `.env.example` |

**Decisões de UX**

- Modal bloqueante (não fecha sem aceitar ou logout).
- Reload após aceite para simplificar sincronização com cache Apollo e permissões.
- Links abrem em nova aba (`target="_blank"`) para leitura dos PDFs/páginas na landing.

### Capturas de tela

_Incluir antes do merge:_

1. Modal de aceite exibido logo após login com usuário sem aceite válido.
2. Modal com links para Termos de Uso e Política de Privacidade.
3. Tela de definir senha com checkbox de aceite obrigatório.
4. (Opcional) Comportamento após bump de versão no backend — modal reaparece até novo aceite.

### Verificações

- [ ] Variáveis `NUXT_PUBLIC_TERMS_OF_USE_URL` e `NUXT_PUBLIC_PRIVACY_POLICY_URL` (ou equivalentes no `.env`) apontam para a landing correta.
- [ ] Build/lint do Nuxt sem erros.
- [ ] Testar login → modal → aceitar → uso normal do app.
- [ ] Testar `userSetPassword` sem marcar checkbox (deve falhar).
- [ ] Testar resposta `TERMS_ACCEPTANCE_REQUIRED` em mutation qualquer (modal abre).

### Test plan

- [ ] Usuário sem aceite: ao entrar no layout `default`, modal visível e ações bloqueadas até confirmar.
- [ ] Aceitar termos: mutation sucesso, reload, modal não reaparece.
- [ ] Simular versão desatualizada no backend: modal volta após `me` ou erro GraphQL.
- [ ] Fluxo set password: checkbox obrigatório; mutation envia `termsAccepted: true`.
- [ ] Links legais abrem URLs configuradas na landing.
- [ ] Regressão: navegação e mutations já existentes funcionam após aceite válido.


[VT-122]: https://zorensoftware.atlassian.net/browse/VT-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ