### PR TITLE
feat(auth): autenticação em duas etapas com TOTP e passkeys - VT-134

### DIFF
--- a/components/organisms/Forms/Login/ZLoginForm.vue
+++ b/components/organisms/Forms/Login/ZLoginForm.vue
@@ -160,6 +160,7 @@ import { confirmSuccess } from "~/utils/sweetAlert2/swalHelper";
 import {
   assertPasskeyCredential,
   credentialToJson,
+  passkeySupportMessage,
   supportsPasskeys,
 } from "~/utils/passkeys";
 
@@ -313,6 +314,7 @@ export default {
 
       if (!supportsPasskeys()) {
         this.passkeyError =
+          passkeySupportMessage() ||
           "Este navegador não oferece chaves de acesso. Use o autenticador.";
         this.showTotpFallback = true;
         return;

--- a/components/organisms/Forms/Login/ZLoginForm.vue
+++ b/components/organisms/Forms/Login/ZLoginForm.vue
@@ -1,7 +1,13 @@
 <template>
   <va-card stripe stripe-color="primary" class="mx-5" style="z-index: 99">
-    <va-card-title> Login </va-card-title>
-    <va-form @keyup.enter="login">
+    <va-card-title>
+      {{ loginStep === "credentials" ? "Login" : "Confirmar acesso" }}
+    </va-card-title>
+    <va-form
+      v-if="loginStep === 'credentials'"
+      @submit.prevent="login"
+      @keyup.enter="login"
+    >
       <div class="row justify-center px-3 pb-4">
         <div class="flex flex-col">
           <div class="item">
@@ -43,8 +49,87 @@
         </ZButton>
       </div>
     </va-form>
+    <va-form
+      v-else
+      class="px-3 pb-4"
+      @submit.prevent="confirmTwoFactorChallenge"
+      @keyup.enter="confirmTwoFactorChallenge"
+    >
+      <div class="two-factor-identity">
+        <va-avatar color="primary" size="42px">
+          {{ challengeInitial }}
+        </va-avatar>
+        <div>
+          <p class="two-factor-signed-in">Conectado como</p>
+          <strong>{{ email }}</strong>
+        </div>
+      </div>
+
+      <template v-if="hasPasskeyMethod">
+        <ZButton
+          :block="true"
+          :loading="loading && passkeyBusy"
+          color="primary"
+          :disabled="loading"
+          @click="confirmPasskeyChallenge"
+        >
+          Usar chave de acesso
+        </ZButton>
+        <p class="two-factor-hint">
+          Confirme com 1Password, Face ID, Touch ID ou outra passkey.
+        </p>
+      </template>
+
+      <div v-if="hasTotpMethod && (!hasPasskeyMethod || showTotpFallback)">
+        <ZInput
+          v-model="twoFactorCode"
+          id="two-factor-code"
+          label="Código do autenticador"
+          placeholder="Digite o código de 6 dígitos"
+          inputmode="numeric"
+          autocomplete="one-time-code"
+          :error="twoFactorError"
+          :error-messages="twoFactorErrorMessage"
+        />
+        <p class="two-factor-hint">
+          Abra seu aplicativo autenticador para obter o código.
+        </p>
+        <ZButton
+          :block="true"
+          :loading="loading && !passkeyBusy"
+          color="primary"
+          :disabled="!twoFactorCode.trim()"
+          type="submit"
+        >
+          Verificar
+        </ZButton>
+      </div>
+
+      <va-button
+        v-if="hasPasskeyMethod && hasTotpMethod && !showTotpFallback"
+        preset="plain"
+        class="mt-2"
+        :disabled="loading"
+        @click="showTotpFallback = true"
+      >
+        Está com problemas?
+      </va-button>
+
+      <p v-if="passkeyError" class="two-factor-error" role="alert">
+        {{ passkeyError }}
+      </p>
+
+      <va-button
+        preset="plain"
+        class="mt-2"
+        :disabled="loading"
+        @click="resetTwoFactorChallenge"
+      >
+        Voltar
+      </va-button>
+    </va-form>
   </va-card>
-  <div class="ml-4 mt-2">
+  <div v-if="loginStep === 'credentials'" class="ml-4 mt-2">
     <div class="row justify-start px-3">
       <div class="flex flex-col">
         <div class="item">
@@ -63,12 +148,20 @@
 
 <script>
 import LOGIN from "~/graphql/user/mutation/login.graphql";
+import CONFIRM_TWO_FACTOR_CHALLENGE from "~/graphql/user/mutation/confirmTwoFactorChallenge.graphql";
+import BEGIN_PASSKEY_CHALLENGE from "~/graphql/user/mutation/beginPasskeyChallenge.graphql";
+import CONFIRM_PASSKEY_CHALLENGE from "~/graphql/user/mutation/confirmPasskeyChallenge.graphql";
 import FORGOT_PASSWORD from "~/graphql/user/mutation/forgotPassword.graphql";
 import ZInput from "~/components/atoms/Inputs/ZInput";
 import ZPasswordInput from "~/components/molecules/Inputs/ZPasswordInput";
 import ZEmailInput from "~/components/molecules/Inputs/ZEmailInput";
 import ZButton from "~/components/atoms/Buttons/ZButton";
 import { confirmSuccess } from "~/utils/sweetAlert2/swalHelper";
+import {
+  assertPasskeyCredential,
+  credentialToJson,
+  supportsPasskeys,
+} from "~/utils/passkeys";
 
 export default {
   components: {
@@ -91,15 +184,29 @@ export default {
       loading: false,
       email: isLocal ? config.public.loginTestEmail || "" : "",
       password: isLocal ? config.public.loginTestPassword || "" : "",
+      loginStep: "credentials",
+      twoFactorChallenge: null,
+      twoFactorCode: "",
+      twoFactorError: false,
+      twoFactorErrorMessage: "",
+      showTotpFallback: false,
+      passkeyBusy: false,
+      passkeyError: "",
     };
   },
 
   methods: {
+    completeLogin(token) {
+      const { onLogin } = useApollo();
+      this.success = true;
+      this.successMessage = ["Login realizado com sucesso"];
+      localStorage.setItem("userToken", token);
+      onLogin(token);
+      this.$router.push("/");
+    },
     async login() {
       try {
         this.loading = true;
-        const { onLogin } = useApollo();
-
         const query = gql`
           ${LOGIN}
         `;
@@ -135,18 +242,23 @@ export default {
 
         const { mutate } = await useMutation(query, { variables });
 
-        const {
-          data: {
-            login: { token },
-          },
-        } = await mutate();
+        const { data } = await mutate();
+        const login = data?.login;
 
-        if (token) {
-          this.success = true;
-          this.successMessage = ["Login realizado com sucesso"];
-          localStorage.setItem("userToken", token);
-          onLogin(token);
-          this.$router.push("/");
+        if (login?.token) {
+          this.completeLogin(login.token);
+          return;
+        }
+
+        if (login?.twoFactorRequired && login.challengeToken) {
+          this.password = "";
+          this.twoFactorChallenge = login;
+          this.twoFactorCode = "";
+          this.twoFactorError = false;
+          this.twoFactorErrorMessage = "";
+          this.showTotpFallback = !(login.methods || []).includes("passkey");
+          this.passkeyError = "";
+          this.loginStep = "two_factor";
         }
       } catch (error) {
         this.errorPassword = true;
@@ -158,6 +270,113 @@ export default {
         }
       }
       this.loading = false;
+    },
+
+    async confirmTwoFactorChallenge() {
+      if (!this.twoFactorCode.trim() || !this.twoFactorChallenge?.challengeToken) {
+        return;
+      }
+
+      try {
+        this.loading = true;
+        this.passkeyBusy = false;
+        this.twoFactorError = false;
+        this.twoFactorErrorMessage = "";
+        const mutation = gql`
+          ${CONFIRM_TWO_FACTOR_CHALLENGE}
+        `;
+        const variables = {
+          challengeToken: this.twoFactorChallenge.challengeToken,
+          code: this.twoFactorCode.trim(),
+        };
+        const { mutate } = await useMutation(mutation, { variables });
+        const { data } = await mutate();
+        const token = data?.confirmTwoFactorChallenge?.token;
+
+        if (token) {
+          this.completeLogin(token);
+        }
+      } catch (error) {
+        this.twoFactorError = true;
+        this.twoFactorErrorMessage =
+          error.graphQLErrors?.[0]?.message ||
+          "Não foi possível verificar o código. Tente novamente.";
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async confirmPasskeyChallenge() {
+      if (!this.twoFactorChallenge?.challengeToken) {
+        return;
+      }
+
+      if (!supportsPasskeys()) {
+        this.passkeyError =
+          "Este navegador não oferece chaves de acesso. Use o autenticador.";
+        this.showTotpFallback = true;
+        return;
+      }
+
+      try {
+        this.loading = true;
+        this.passkeyBusy = true;
+        this.passkeyError = "";
+
+        const beginMutation = gql`
+          ${BEGIN_PASSKEY_CHALLENGE}
+        `;
+        const { mutate: beginMutate } = await useMutation(beginMutation, {
+          variables: {
+            challengeToken: this.twoFactorChallenge.challengeToken,
+          },
+        });
+        const { data: beginData } = await beginMutate();
+        const begin = beginData?.beginPasskeyChallenge;
+
+        if (!begin?.optionsJson || !begin?.assertionId) {
+          throw new Error("Não foi possível iniciar a verificação com passkey.");
+        }
+
+        const credential = await assertPasskeyCredential(begin.optionsJson);
+        const confirmMutation = gql`
+          ${CONFIRM_PASSKEY_CHALLENGE}
+        `;
+        const { mutate: confirmMutate } = await useMutation(confirmMutation, {
+          variables: {
+            challengeToken: this.twoFactorChallenge.challengeToken,
+            assertionId: begin.assertionId,
+            credentialJson: credentialToJson(credential),
+          },
+        });
+        const { data: confirmData } = await confirmMutate();
+        const token = confirmData?.confirmPasskeyChallenge?.token;
+
+        if (token) {
+          this.completeLogin(token);
+        }
+      } catch (error) {
+        this.passkeyError =
+          error.graphQLErrors?.[0]?.message ||
+          error.message ||
+          "Não foi possível confirmar a chave de acesso.";
+        if (this.hasTotpMethod) {
+          this.showTotpFallback = true;
+        }
+      } finally {
+        this.loading = false;
+        this.passkeyBusy = false;
+      }
+    },
+
+    resetTwoFactorChallenge() {
+      this.loginStep = "credentials";
+      this.twoFactorChallenge = null;
+      this.twoFactorCode = "";
+      this.twoFactorError = false;
+      this.twoFactorErrorMessage = "";
+      this.showTotpFallback = false;
+      this.passkeyError = "";
     },
 
     async resetPassword() {
@@ -198,5 +417,48 @@ export default {
       this.loading = false;
     },
   },
+  computed: {
+    hasTotpMethod() {
+      return this.twoFactorChallenge?.methods?.includes("totp") ?? false;
+    },
+    hasPasskeyMethod() {
+      return this.twoFactorChallenge?.methods?.includes("passkey") ?? false;
+    },
+    challengeInitial() {
+      return (this.twoFactorChallenge?.name || this.email || "?")
+        .charAt(0)
+        .toUpperCase();
+    },
+  },
 };
 </script>
+
+<style scoped>
+.two-factor-identity {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  margin-bottom: 20px;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.two-factor-signed-in {
+  margin: 0 0 2px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.two-factor-hint {
+  margin: 6px 0 18px;
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.two-factor-error {
+  margin: 8px 0 0;
+  color: #b91c1c;
+  font-size: 13px;
+}
+</style>

--- a/graphql/user/mutation/beginPasskeyChallenge.graphql
+++ b/graphql/user/mutation/beginPasskeyChallenge.graphql
@@ -1,0 +1,6 @@
+mutation beginPasskeyChallenge($challengeToken: String!) {
+  beginPasskeyChallenge(input: { challengeToken: $challengeToken }) {
+    optionsJson
+    assertionId
+  }
+}

--- a/graphql/user/mutation/beginPasskeyRegistration.graphql
+++ b/graphql/user/mutation/beginPasskeyRegistration.graphql
@@ -1,0 +1,6 @@
+mutation beginPasskeyRegistration {
+  beginPasskeyRegistration {
+    optionsJson
+    registrationId
+  }
+}

--- a/graphql/user/mutation/confirmPasskeyChallenge.graphql
+++ b/graphql/user/mutation/confirmPasskeyChallenge.graphql
@@ -1,0 +1,16 @@
+mutation confirmPasskeyChallenge(
+  $challengeToken: String!
+  $assertionId: String!
+  $credentialJson: String!
+) {
+  confirmPasskeyChallenge(
+    input: {
+      challengeToken: $challengeToken
+      assertionId: $assertionId
+      credentialJson: $credentialJson
+    }
+  ) {
+    token
+    twoFactorRequired
+  }
+}

--- a/graphql/user/mutation/confirmPasskeyRegistration.graphql
+++ b/graphql/user/mutation/confirmPasskeyRegistration.graphql
@@ -1,0 +1,22 @@
+mutation confirmPasskeyRegistration(
+  $registrationId: String!
+  $name: String!
+  $credentialJson: String!
+) {
+  confirmPasskeyRegistration(
+    input: {
+      registrationId: $registrationId
+      name: $name
+      credentialJson: $credentialJson
+    }
+  ) {
+    id
+    name
+    authenticator
+    twoFactorEnabled
+    methods
+    totpEnabled
+    passkeyEnabled
+    recoveryCodesRemaining
+  }
+}

--- a/graphql/user/mutation/confirmTotp.graphql
+++ b/graphql/user/mutation/confirmTotp.graphql
@@ -1,0 +1,10 @@
+mutation confirmTotp($code: String!) {
+  confirmTotp(input: { code: $code }) {
+    recoveryCodes
+    twoFactorEnabled
+    totpEnabled
+    methods
+    passkeyEnabled
+    recoveryCodesRemaining
+  }
+}

--- a/graphql/user/mutation/confirmTwoFactorChallenge.graphql
+++ b/graphql/user/mutation/confirmTwoFactorChallenge.graphql
@@ -1,0 +1,8 @@
+mutation confirmTwoFactorChallenge($challengeToken: String!, $code: String!) {
+  confirmTwoFactorChallenge(
+    input: { challengeToken: $challengeToken, code: $code }
+  ) {
+    token
+    twoFactorRequired
+  }
+}

--- a/graphql/user/mutation/deletePasskey.graphql
+++ b/graphql/user/mutation/deletePasskey.graphql
@@ -1,0 +1,9 @@
+mutation deletePasskey($id: ID!, $password: String!) {
+  deletePasskey(input: { id: $id, password: $password }) {
+    twoFactorEnabled
+    methods
+    totpEnabled
+    passkeyEnabled
+    recoveryCodesRemaining
+  }
+}

--- a/graphql/user/mutation/disableTotp.graphql
+++ b/graphql/user/mutation/disableTotp.graphql
@@ -1,0 +1,9 @@
+mutation disableTotp($password: String!, $code: String!) {
+  disableTotp(input: { password: $password, code: $code }) {
+    twoFactorEnabled
+    totpEnabled
+    methods
+    passkeyEnabled
+    recoveryCodesRemaining
+  }
+}

--- a/graphql/user/mutation/enableTotp.graphql
+++ b/graphql/user/mutation/enableTotp.graphql
@@ -1,0 +1,7 @@
+mutation enableTotp {
+  enableTotp {
+    secret
+    otpauthUrl
+    qrCodeSvg
+  }
+}

--- a/graphql/user/mutation/login.graphql
+++ b/graphql/user/mutation/login.graphql
@@ -1,10 +1,14 @@
 mutation login($email: String!, $password: String!) {
   login(
     input: {
-      email: $email,
+      email: $email
       password: $password
     }
-  ){
+  ) {
     token
+    twoFactorRequired
+    challengeToken
+    methods
+    expiresIn
   }
 }

--- a/graphql/user/query/passkeys.graphql
+++ b/graphql/user/query/passkeys.graphql
@@ -1,0 +1,9 @@
+query passkeys {
+  passkeys {
+    id
+    name
+    authenticator
+    lastUsedAt
+    createdAt
+  }
+}

--- a/graphql/user/query/twoFactorStatus.graphql
+++ b/graphql/user/query/twoFactorStatus.graphql
@@ -1,0 +1,9 @@
+query twoFactorStatus {
+  twoFactorStatus {
+    twoFactorEnabled
+    methods
+    totpEnabled
+    passkeyEnabled
+    recoveryCodesRemaining
+  }
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -116,6 +116,16 @@
             </NuxtLink>
           </div>
         </div>
+        <NuxtLink
+          v-if="showTwoFactorSidebarWarning"
+          to="/settings/security"
+          class="sidebar-link sidebar-link--security-attention"
+          :class="{ active: isRouteActive('/settings/security') }"
+          title="Proteja sua conta ativando a verificação em duas etapas."
+        >
+          <va-icon name="shield" size="20px" class="sidebar-link-icon" />
+          <span class="sidebar-link-text">Ativar verificação em 2 etapas</span>
+        </NuxtLink>
         <button
           type="button"
           class="sidebar-link sidebar-link--logout"
@@ -211,16 +221,6 @@
         </div>
       </div>
       <div class="content-wrapper">
-        <div
-          v-if="twoFactorStatus && !twoFactorStatus.twoFactorEnabled"
-          class="two-factor-banner"
-        >
-          <va-icon name="shield" size="20px" />
-          <span>Proteja sua conta ativando a verificação em duas etapas.</span>
-          <NuxtLink to="/settings/security" class="two-factor-banner-link">
-            Configurar
-          </NuxtLink>
-        </div>
         <NuxtPage />
       </div>
     </div>
@@ -288,6 +288,9 @@ export default {
       }
       const names = roles.map((r) => r?.name).filter(Boolean);
       return names.length ? names.join(" • ") : "Sem função definida";
+    },
+    showTwoFactorSidebarWarning() {
+      return this.twoFactorStatus?.twoFactorEnabled === false;
     },
     activePlanIcon() {
       if (!this.activePlanData) {
@@ -600,6 +603,7 @@ export default {
   watch: {
     $route() {
       this.closeMobileSidebar();
+      this.loadTwoFactorStatus();
     },
   },
   mounted() {
@@ -968,6 +972,44 @@ button.sidebar-link {
   color: #fca5a5;
 }
 
+.sidebar-link--security-attention {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 180, 80, 0.35);
+  color: #ffd59a;
+  background: rgba(255, 180, 80, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 180, 80, 0.55);
+}
+
+.sidebar-link--security-attention .sidebar-link-icon {
+  color: #ffd59a !important;
+}
+
+.sidebar-link--security-attention:hover {
+  background: rgba(255, 180, 80, 0.2);
+  color: #ffe4b8;
+  box-shadow: inset 0 0 0 1px rgba(255, 200, 120, 0.9);
+}
+
+.sidebar-link--security-attention:hover .sidebar-link-icon {
+  color: #ffe4b8 !important;
+}
+
+.sidebar-link--security-attention.active {
+  background: rgba(255, 180, 80, 0.22);
+  color: #ffe4b8;
+}
+
+.sidebar-link--security-attention.active .sidebar-link-icon {
+  color: #ffe4b8 !important;
+}
+
+.sidebar-link--security-attention + .sidebar-link--logout {
+  margin-top: 8px;
+  padding-top: 10px;
+  border-top: none;
+}
+
 .sidebar-link--logout .sidebar-link-icon {
   color: #fca5a5 !important;
 }
@@ -1010,30 +1052,6 @@ button.sidebar-link {
   display: flex;
   flex-direction: column;
   min-height: 0;
-}
-
-.two-factor-banner {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin: 16px 24px 0;
-  padding: 10px 14px;
-  border: 1px solid #fde68a;
-  border-radius: 8px;
-  color: #92400e;
-  background: #fffbeb;
-  font-size: 13px;
-}
-
-.two-factor-banner-link {
-  margin-left: auto;
-  color: #b45309;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.two-factor-banner-link:hover {
-  text-decoration: underline;
 }
 
 .sidebar-is-collapsed .sidebar {
@@ -1719,6 +1737,16 @@ button.sidebar-link {
     margin-top: 8px;
     flex-basis: 100%;
     width: 100%;
+  }
+
+  .sidebar-link--security-attention {
+    margin-top: 8px;
+    flex-basis: 100%;
+    width: 100%;
+  }
+
+  .sidebar-link--security-attention + .sidebar-link--logout {
+    margin-top: 6px;
   }
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -87,6 +87,14 @@
               <span>Dispositivos</span>
             </NuxtLink>
             <NuxtLink
+              to="/settings/security"
+              class="dropdown-item"
+              @click="closeDropdown"
+            >
+              <va-icon name="security" size="18px" class="dropdown-item-icon" />
+              <span>Segurança</span>
+            </NuxtLink>
+            <NuxtLink
               to="/settings/audit"
               class="dropdown-item"
               @click="closeDropdown"
@@ -203,6 +211,16 @@
         </div>
       </div>
       <div class="content-wrapper">
+        <div
+          v-if="twoFactorStatus && !twoFactorStatus.twoFactorEnabled"
+          class="two-factor-banner"
+        >
+          <va-icon name="shield" size="20px" />
+          <span>Proteja sua conta ativando a verificação em duas etapas.</span>
+          <NuxtLink to="/settings/security" class="two-factor-banner-link">
+            Configurar
+          </NuxtLink>
+        </div>
         <NuxtPage />
       </div>
     </div>
@@ -219,6 +237,7 @@ import ZTermsAcceptanceModal from "~/components/organisms/Modal/ZTermsAcceptance
 import { useTermsAcceptance } from "~/composables/useTermsAcceptance";
 import NOTIFICATIONSTOTAL from "~/graphql/notification/query/notificationsTotal.graphql";
 import ME from "~/graphql/user/query/me.graphql";
+import TWO_FACTOR_STATUS from "~/graphql/user/query/twoFactorStatus.graphql";
 import { getActivePlan } from "~/services/stripeCheckoutService.js";
 import { version as appVersion } from "~/package.json";
 
@@ -250,6 +269,7 @@ export default {
         roles: [],
       },
       activePlanData: null,
+      twoFactorStatus: null,
       appVersion,
     };
   },
@@ -585,6 +605,7 @@ export default {
   mounted() {
     this.notificationsTotal();
     this.getUser();
+    this.loadTwoFactorStatus();
     this.loadActivePlan();
     // Fechar dropdown ao clicar fora
     document.addEventListener("click", this.handleClickOutside);
@@ -643,6 +664,7 @@ export default {
         currentPath === "/settings" ||
         currentPath === "/settings/notifications" ||
         currentPath === "/settings/devices" ||
+        currentPath === "/settings/security" ||
         currentPath === "/settings/audit" ||
         currentPath === "/settings/privacy"
       );
@@ -764,6 +786,26 @@ export default {
         } catch {
           /* ignore */
         }
+      }
+    },
+    async loadTwoFactorStatus() {
+      const token =
+        localStorage.getItem("userToken") ||
+        localStorage.getItem("apollo:default.token");
+      if (!token) {
+        return;
+      }
+
+      try {
+        const query = gql`
+          ${TWO_FACTOR_STATUS}
+        `;
+        const {
+          data: { value },
+        } = await useAsyncQuery(query, {});
+        this.twoFactorStatus = value?.twoFactorStatus ?? null;
+      } catch {
+        this.twoFactorStatus = null;
       }
     },
     async loadActivePlan() {
@@ -968,6 +1010,30 @@ button.sidebar-link {
   display: flex;
   flex-direction: column;
   min-height: 0;
+}
+
+.two-factor-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 16px 24px 0;
+  padding: 10px 14px;
+  border: 1px solid #fde68a;
+  border-radius: 8px;
+  color: #92400e;
+  background: #fffbeb;
+  font-size: 13px;
+}
+
+.two-factor-banner-link {
+  margin-left: auto;
+  color: #b45309;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.two-factor-banner-link:hover {
+  text-decoration: underline;
 }
 
 .sidebar-is-collapsed .sidebar {

--- a/middleware/apollo.global.ts
+++ b/middleware/apollo.global.ts
@@ -21,14 +21,16 @@ export default defineNuxtPlugin(nuxtAppMain => {
 
   const httpLink = new HttpLink({ uri: `${getApiUrl()}/graphql`, })
 
-  const token = localStorage.getItem('userToken'); // Recuperar o token do localStorage
-
   const authLink = setContext((_, { headers }) => {
+    const token =
+      localStorage.getItem('userToken') ||
+      localStorage.getItem('apollo:default.token')
+
     return {
       headers: {
         ...headers,
         'x-tenant': getTenant(),
-        'Authorization': token ? `Bearer ${token}` : "", // Incluir o token no cabeçalho de autorização
+        'Authorization': token ? `Bearer ${token}` : '',
       },
     }
   })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "sass": "^1.94.2"
   },
   "dependencies": {
+    "@simplewebauthn/browser": "^13.3.0",
     "@stripe/stripe-js": "^2.4.0",
     "@vuestic/nuxt": "^1.0.21",
     "chart.js": "^4.5.1",

--- a/pages/settings/security.vue
+++ b/pages/settings/security.vue
@@ -1,0 +1,759 @@
+<template>
+  <div class="security-page">
+    <div class="page-header">
+      <h1 class="page-title">Segurança da conta</h1>
+      <p class="page-subtitle">
+        Proteja sua conta com a verificação em duas etapas.
+      </p>
+    </div>
+
+    <section class="security-card">
+      <div v-if="loading" class="loading-wrapper">
+        <va-progress-circle indeterminate color="#FF4E1B" />
+      </div>
+
+      <template v-else-if="status">
+        <div
+          class="status-banner"
+          :class="status?.twoFactorEnabled ? 'status-banner--enabled' : 'status-banner--disabled'"
+        >
+          <va-icon
+            :name="status?.twoFactorEnabled ? 'verified_user' : 'security'"
+            size="24px"
+          />
+          <div>
+            <strong>
+              {{
+                status?.twoFactorEnabled
+                  ? "Verificação em duas etapas ativada"
+                  : "Verificação em duas etapas desativada"
+              }}
+            </strong>
+            <p>
+              {{
+                status?.twoFactorEnabled
+                  ? "Sua conta exige verificação adicional ao entrar."
+                  : "Adicione uma camada extra de proteção ao seu acesso."
+              }}
+            </p>
+          </div>
+        </div>
+
+        <div class="security-section">
+          <div class="section-heading">
+            <div class="security-icon">
+              <va-icon name="phonelink_lock" size="24px" color="#FF4E1B" />
+            </div>
+            <div>
+              <h2>Aplicativo autenticador</h2>
+              <p>
+                Use Google Authenticator, Authy ou outro aplicativo compatível
+                para gerar códigos de acesso.
+              </p>
+            </div>
+          </div>
+
+          <template v-if="!status?.totpEnabled && !totpSetup">
+            <va-button color="primary" :loading="busy" @click="enableTotp">
+              Ativar aplicativo autenticador
+            </va-button>
+          </template>
+
+          <template v-else-if="totpSetup">
+            <div class="setup-panel">
+              <p>Escaneie o QR Code no seu aplicativo autenticador.</p>
+              <div class="qr-code" v-html="totpSetup.qrCodeSvg" />
+              <p class="manual-secret">
+                Não consegue escanear? Informe esta chave manualmente:
+                <code>{{ totpSetup.secret }}</code>
+              </p>
+              <va-input
+                v-model="confirmCode"
+                label="Código de confirmação"
+                placeholder="Digite o código de 6 dígitos"
+                inputmode="numeric"
+                autocomplete="one-time-code"
+                class="code-input"
+              />
+              <va-button
+                color="primary"
+                :loading="busy"
+                :disabled="!confirmCode.trim()"
+                @click="confirmTotp"
+              >
+                Confirmar e ativar
+              </va-button>
+            </div>
+          </template>
+
+          <template v-else>
+            <p class="recovery-remaining">
+              Códigos de recuperação disponíveis:
+              <strong>{{ status?.recoveryCodesRemaining ?? 0 }}</strong>
+            </p>
+            <div class="disable-panel">
+              <h3>Desativar aplicativo autenticador</h3>
+              <p>Confirme sua senha e um código atual para continuar.</p>
+              <va-input
+                v-model="disablePassword"
+                type="password"
+                label="Senha atual"
+                autocomplete="current-password"
+              />
+              <va-input
+                v-model="disableCode"
+                label="Código do autenticador"
+                placeholder="Digite o código de 6 dígitos"
+                inputmode="numeric"
+                autocomplete="one-time-code"
+              />
+              <va-button
+                color="danger"
+                :loading="busy"
+                :disabled="!disablePassword || !disableCode.trim()"
+                @click="disableTotp"
+              >
+                Desativar
+              </va-button>
+            </div>
+          </template>
+        </div>
+
+        <div v-if="recoveryCodes.length" class="recovery-panel">
+          <h2>Guarde seus códigos de recuperação</h2>
+          <p>
+            Eles só serão exibidos agora. Salve-os em um local seguro para
+            recuperar o acesso caso perca seu autenticador.
+          </p>
+          <div class="recovery-codes">
+            <code v-for="code in recoveryCodes" :key="code">{{ code }}</code>
+          </div>
+        </div>
+
+        <div class="security-section security-section--last">
+          <div class="section-heading">
+            <div class="security-icon">
+              <va-icon name="key" size="24px" color="#FF4E1B" />
+            </div>
+            <div>
+              <h2>Chaves de acesso</h2>
+              <p>
+                Use 1Password, Face ID, Touch ID ou outra passkey para confirmar
+                o acesso sem digitar códigos.
+              </p>
+            </div>
+          </div>
+
+          <va-button
+            color="primary"
+            :loading="passkeyBusy"
+            :disabled="!passkeysSupported"
+            @click="addPasskey"
+          >
+            Adicionar chave de acesso
+          </va-button>
+          <p v-if="!passkeysSupported" class="passkey-unsupported">
+            Este navegador não oferece chaves de acesso.
+          </p>
+
+          <div v-if="passkeysLoading" class="passkey-loading">
+            Carregando chaves...
+          </div>
+          <p v-else-if="passkeys.length === 0" class="passkey-empty">
+            Nenhuma chave de acesso cadastrada.
+          </p>
+          <ul v-else class="passkey-list">
+            <li v-for="passkey in passkeys" :key="passkey.id" class="passkey-item">
+              <div>
+                <strong>{{ passkey.name }}</strong>
+                <p>
+                  {{ passkey.authenticator || "Autenticador" }}
+                  · Último uso:
+                  {{ formatDate(passkey.lastUsedAt) || "nunca" }}
+                </p>
+              </div>
+              <va-button
+                color="danger"
+                preset="secondary"
+                size="small"
+                :loading="deletingPasskeyId === passkey.id"
+                :disabled="passkeyBusy"
+                @click="startDeletePasskey(passkey)"
+              >
+                Remover
+              </va-button>
+            </li>
+          </ul>
+
+          <div v-if="passkeyToDelete" class="disable-panel passkey-delete-panel">
+            <h3>Remover chave de acesso</h3>
+            <p>
+              Confirme sua senha para remover
+              <strong>{{ passkeyToDelete.name }}</strong>.
+            </p>
+            <va-input
+              v-model="deletePasskeyPassword"
+              type="password"
+              label="Senha atual"
+              autocomplete="current-password"
+            />
+            <div class="passkey-delete-actions">
+              <va-button
+                color="danger"
+                :loading="deletingPasskeyId === passkeyToDelete.id"
+                :disabled="!deletePasskeyPassword"
+                @click="deletePasskey"
+              >
+                Confirmar remoção
+              </va-button>
+              <va-button preset="plain" :disabled="passkeyBusy" @click="resetDeletePasskey">
+                Cancelar
+              </va-button>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <div v-else class="status-unavailable">
+        Não foi possível carregar as configurações de segurança.
+      </div>
+
+      <p v-if="errorMessage" class="error-message" role="alert">
+        {{ errorMessage }}
+      </p>
+    </section>
+
+    <div class="action-buttons">
+      <va-button preset="secondary" @click="$router.push('/settings')">
+        <va-icon name="arrow_back" size="16px" />
+        Voltar
+      </va-button>
+    </div>
+  </div>
+</template>
+
+<script>
+import TWO_FACTOR_STATUS from "~/graphql/user/query/twoFactorStatus.graphql";
+import PASSKEYS from "~/graphql/user/query/passkeys.graphql";
+import ENABLE_TOTP from "~/graphql/user/mutation/enableTotp.graphql";
+import CONFIRM_TOTP from "~/graphql/user/mutation/confirmTotp.graphql";
+import DISABLE_TOTP from "~/graphql/user/mutation/disableTotp.graphql";
+import BEGIN_PASSKEY_REGISTRATION from "~/graphql/user/mutation/beginPasskeyRegistration.graphql";
+import CONFIRM_PASSKEY_REGISTRATION from "~/graphql/user/mutation/confirmPasskeyRegistration.graphql";
+import DELETE_PASSKEY from "~/graphql/user/mutation/deletePasskey.graphql";
+import { confirmSuccess } from "~/utils/sweetAlert2/swalHelper";
+import {
+  createPasskeyCredential,
+  credentialToJson,
+  supportsPasskeys,
+} from "~/utils/passkeys";
+
+export default {
+  name: "SecuritySettingsPage",
+  data() {
+    return {
+      status: null,
+      loading: true,
+      busy: false,
+      errorMessage: "",
+      totpSetup: null,
+      confirmCode: "",
+      disablePassword: "",
+      disableCode: "",
+      recoveryCodes: [],
+      passkeys: [],
+      passkeysLoading: false,
+      passkeyBusy: false,
+      passkeysSupported: supportsPasskeys(),
+      passkeyToDelete: null,
+      deletePasskeyPassword: "",
+      deletingPasskeyId: null,
+    };
+  },
+  mounted() {
+    this.loadStatus();
+    this.loadPasskeys();
+  },
+  methods: {
+    async loadStatus() {
+      this.loading = true;
+      this.errorMessage = "";
+
+      try {
+        const query = gql`
+          ${TWO_FACTOR_STATUS}
+        `;
+        const { data } = await useAsyncQuery(query, {});
+        this.status = data.value?.twoFactorStatus ?? null;
+      } catch (error) {
+        this.errorMessage = this.getErrorMessage(
+          error,
+          "Não foi possível carregar as configurações de segurança.",
+        );
+      } finally {
+        this.loading = false;
+      }
+    },
+    async loadPasskeys() {
+      this.passkeysLoading = true;
+
+      try {
+        const query = gql`
+          ${PASSKEYS}
+        `;
+        const { data } = await useAsyncQuery(query, {});
+        this.passkeys = data.value?.passkeys ?? [];
+      } catch (error) {
+        this.errorMessage = this.getErrorMessage(
+          error,
+          "Não foi possível carregar as chaves de acesso.",
+        );
+      } finally {
+        this.passkeysLoading = false;
+      }
+    },
+    async enableTotp() {
+      await this.runMutation(ENABLE_TOTP, {}, (data) => {
+        this.totpSetup = data?.enableTotp ?? null;
+        this.confirmCode = "";
+      });
+    },
+    async confirmTotp() {
+      await this.runMutation(
+        CONFIRM_TOTP,
+        { code: this.confirmCode.trim() },
+        (data) => {
+          const result = data?.confirmTotp;
+          if (!result) {
+            return;
+          }
+
+          this.status = result;
+          this.recoveryCodes = result.recoveryCodes ?? [];
+          this.totpSetup = null;
+          this.confirmCode = "";
+          confirmSuccess("Verificação em duas etapas ativada com sucesso!");
+        },
+      );
+    },
+    async disableTotp() {
+      await this.runMutation(
+        DISABLE_TOTP,
+        {
+          password: this.disablePassword,
+          code: this.disableCode.trim(),
+        },
+        (data) => {
+          this.status = data?.disableTotp ?? {
+            twoFactorEnabled: false,
+            totpEnabled: false,
+            methods: [],
+            passkeyEnabled: false,
+            recoveryCodesRemaining: 0,
+          };
+          this.disablePassword = "";
+          this.disableCode = "";
+          this.recoveryCodes = [];
+          confirmSuccess("Aplicativo autenticador desativado.");
+        },
+      );
+    },
+    async addPasskey() {
+      if (!this.passkeysSupported) {
+        return;
+      }
+
+      this.passkeyBusy = true;
+      this.errorMessage = "";
+
+      try {
+        const beginMutation = gql`
+          ${BEGIN_PASSKEY_REGISTRATION}
+        `;
+        const { mutate: beginMutate } = await useMutation(beginMutation, {
+          variables: {},
+        });
+        const { data: beginData } = await beginMutate();
+        const begin = beginData?.beginPasskeyRegistration;
+
+        if (!begin?.optionsJson || !begin?.registrationId) {
+          throw new Error("Não foi possível iniciar o registro da passkey.");
+        }
+
+        const credential = await createPasskeyCredential(begin.optionsJson);
+        const defaultName =
+          typeof navigator !== "undefined" && navigator.userAgentData?.platform
+            ? navigator.userAgentData.platform
+            : "Este dispositivo";
+
+        await this.runMutation(
+          CONFIRM_PASSKEY_REGISTRATION,
+          {
+            registrationId: begin.registrationId,
+            name: defaultName,
+            credentialJson: credentialToJson(credential),
+          },
+          (data) => {
+            const result = data?.confirmPasskeyRegistration;
+            if (!result) {
+              return;
+            }
+
+            this.status = {
+              twoFactorEnabled: result.twoFactorEnabled,
+              methods: result.methods,
+              totpEnabled: result.totpEnabled,
+              passkeyEnabled: result.passkeyEnabled,
+              recoveryCodesRemaining: result.recoveryCodesRemaining,
+            };
+            confirmSuccess("Chave de acesso adicionada com sucesso!");
+          },
+        );
+
+        await this.loadPasskeys();
+      } catch (error) {
+        this.errorMessage = this.getErrorMessage(
+          error,
+          "Não foi possível adicionar a chave de acesso.",
+        );
+      } finally {
+        this.passkeyBusy = false;
+      }
+    },
+    startDeletePasskey(passkey) {
+      this.passkeyToDelete = passkey;
+      this.deletePasskeyPassword = "";
+    },
+    resetDeletePasskey() {
+      this.passkeyToDelete = null;
+      this.deletePasskeyPassword = "";
+      this.deletingPasskeyId = null;
+    },
+    async deletePasskey() {
+      if (!this.passkeyToDelete || !this.deletePasskeyPassword) {
+        return;
+      }
+
+      this.deletingPasskeyId = this.passkeyToDelete.id;
+      this.passkeyBusy = true;
+
+      await this.runMutation(
+        DELETE_PASSKEY,
+        {
+          id: this.passkeyToDelete.id,
+          password: this.deletePasskeyPassword,
+        },
+        (data) => {
+          this.status = data?.deletePasskey ?? this.status;
+          this.resetDeletePasskey();
+          confirmSuccess("Chave de acesso removida.");
+        },
+      );
+
+      this.passkeyBusy = false;
+      this.deletingPasskeyId = null;
+      await this.loadPasskeys();
+    },
+    formatDate(value) {
+      if (!value) {
+        return "";
+      }
+
+      try {
+        return new Date(value).toLocaleString("pt-BR");
+      } catch {
+        return value;
+      }
+    },
+    async runMutation(document, variables, onSuccess) {
+      this.busy = true;
+      this.errorMessage = "";
+
+      try {
+        const mutation = gql`
+          ${document}
+        `;
+        const { mutate } = await useMutation(mutation, { variables });
+        const { data } = await mutate();
+        onSuccess(data);
+      } catch (error) {
+        this.errorMessage = this.getErrorMessage(
+          error,
+          "Não foi possível concluir esta ação. Tente novamente.",
+        );
+      } finally {
+        this.busy = false;
+      }
+    },
+    getErrorMessage(error, fallback) {
+      return error.graphQLErrors?.[0]?.message || error.message || fallback;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.security-page {
+  max-width: 720px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.page-header {
+  margin-bottom: 24px;
+}
+
+.page-title {
+  margin: 0 0 8px;
+  font-size: 28px;
+  font-weight: 700;
+  color: #0b1e3a;
+}
+
+.page-subtitle {
+  margin: 0;
+  color: #6c757d;
+  font-size: 15px;
+}
+
+.security-card {
+  padding: 24px;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.loading-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 40px;
+}
+
+.status-banner,
+.section-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.status-banner {
+  padding: 14px;
+  border: 1px solid;
+  border-radius: 10px;
+  margin-bottom: 24px;
+}
+
+.status-banner--enabled {
+  color: #065f46;
+  border-color: #a7f3d0;
+  background: #ecfdf5;
+}
+
+.status-banner--disabled {
+  color: #92400e;
+  border-color: #fde68a;
+  background: #fffbeb;
+}
+
+.status-banner p,
+.section-heading p,
+.disable-panel p,
+.recovery-panel p,
+.passkey-item p {
+  margin: 4px 0 0;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.security-section {
+  padding-bottom: 24px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.security-section--last {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.security-icon {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: #fff5f2;
+  flex-shrink: 0;
+}
+
+.section-heading {
+  margin-bottom: 20px;
+}
+
+.section-heading h2,
+.recovery-panel h2,
+.disable-panel h3 {
+  margin: 0;
+  color: #0b1e3a;
+}
+
+.section-heading h2,
+.recovery-panel h2 {
+  font-size: 17px;
+}
+
+.setup-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.setup-panel > p {
+  margin: 0 0 12px;
+  color: #4b5563;
+  font-size: 14px;
+}
+
+.qr-code {
+  display: grid;
+  place-items: center;
+  align-self: center;
+  padding: 12px;
+  margin: 4px 0 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+}
+
+.qr-code :deep(svg) {
+  width: 180px;
+  height: 180px;
+}
+
+.manual-secret {
+  word-break: break-all;
+}
+
+.manual-secret code,
+.recovery-codes code {
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: #f3f4f6;
+  color: #374151;
+}
+
+.code-input,
+.disable-panel :deep(.va-input-wrapper) {
+  width: 100%;
+  margin-bottom: 12px;
+}
+
+.recovery-remaining {
+  margin: 0 0 16px;
+  color: #4b5563;
+  font-size: 14px;
+}
+
+.disable-panel {
+  padding: 16px;
+  border-radius: 10px;
+  background: #fef2f2;
+}
+
+.disable-panel h3 {
+  color: #991b1b;
+  font-size: 15px;
+}
+
+.disable-panel p {
+  margin-bottom: 14px;
+  color: #7f1d1d;
+}
+
+.recovery-panel {
+  margin-top: 24px;
+  padding: 18px;
+  border: 1px solid #bfdbfe;
+  border-radius: 10px;
+  background: #eff6ff;
+}
+
+.recovery-panel p {
+  color: #1e3a8a;
+}
+
+.recovery-codes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.recovery-codes code {
+  text-align: center;
+}
+
+.passkey-unsupported,
+.passkey-empty,
+.passkey-loading {
+  margin: 12px 0 0;
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.passkey-list {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+}
+
+.passkey-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid #e5e7eb;
+}
+
+.passkey-item:first-child {
+  border-top: 0;
+}
+
+.passkey-delete-panel {
+  margin-top: 16px;
+}
+
+.passkey-delete-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.error-message {
+  margin: 16px 0 0;
+  color: #b91c1c;
+  font-size: 14px;
+}
+
+.status-unavailable {
+  padding: 16px;
+  border-radius: 8px;
+  color: #991b1b;
+  background: #fef2f2;
+}
+
+.action-buttons {
+  margin-top: 20px;
+}
+
+@media (max-width: 480px) {
+  .security-card {
+    padding: 16px;
+  }
+
+  .recovery-codes {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/pages/settings/security.vue
+++ b/pages/settings/security.vue
@@ -153,7 +153,7 @@
             Adicionar chave de acesso
           </va-button>
           <p v-if="!passkeysSupported" class="passkey-unsupported">
-            Este navegador não oferece chaves de acesso.
+            {{ passkeyUnsupportedMessage }}
           </p>
 
           <div v-if="passkeysLoading" class="passkey-loading">
@@ -215,7 +215,16 @@
       </template>
 
       <div v-else class="status-unavailable">
-        Não foi possível carregar as configurações de segurança.
+        <p>Não foi possível carregar as configurações de segurança.</p>
+        <va-button
+          color="primary"
+          preset="secondary"
+          size="small"
+          :loading="loading"
+          @click="reloadSecuritySettings"
+        >
+          Tentar novamente
+        </va-button>
       </div>
 
       <p v-if="errorMessage" class="error-message" role="alert">
@@ -233,6 +242,7 @@
 </template>
 
 <script>
+import { gql } from "@apollo/client/core";
 import TWO_FACTOR_STATUS from "~/graphql/user/query/twoFactorStatus.graphql";
 import PASSKEYS from "~/graphql/user/query/passkeys.graphql";
 import ENABLE_TOTP from "~/graphql/user/mutation/enableTotp.graphql";
@@ -245,6 +255,7 @@ import { confirmSuccess } from "~/utils/sweetAlert2/swalHelper";
 import {
   createPasskeyCredential,
   credentialToJson,
+  passkeySupportMessage,
   supportsPasskeys,
 } from "~/utils/passkeys";
 
@@ -264,28 +275,65 @@ export default {
       passkeys: [],
       passkeysLoading: false,
       passkeyBusy: false,
-      passkeysSupported: supportsPasskeys(),
+      passkeysSupported: false,
+      passkeyUnsupportedMessage: "",
       passkeyToDelete: null,
       deletePasskeyPassword: "",
       deletingPasskeyId: null,
     };
   },
   mounted() {
-    this.loadStatus();
-    this.loadPasskeys();
+    this.refreshPasskeySupport();
+    this.reloadSecuritySettings();
   },
   methods: {
+    refreshPasskeySupport() {
+      this.passkeysSupported = supportsPasskeys();
+      this.passkeyUnsupportedMessage = passkeySupportMessage();
+    },
+    getApolloClient() {
+      return useNuxtApp()._apolloClients?.default ?? null;
+    },
+    async waitForApolloClient(attempts = 10) {
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        const client = this.getApolloClient();
+        if (client) {
+          return client;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+
+      return null;
+    },
+    async reloadSecuritySettings() {
+      await Promise.all([this.loadStatus(), this.loadPasskeys()]);
+    },
     async loadStatus() {
       this.loading = true;
       this.errorMessage = "";
 
       try {
-        const query = gql`
-          ${TWO_FACTOR_STATUS}
-        `;
-        const { data } = await useAsyncQuery(query, {});
-        this.status = data.value?.twoFactorStatus ?? null;
+        const client = await this.waitForApolloClient();
+        if (!client) {
+          throw new Error("Cliente GraphQL indisponível. Recarregue a página.");
+        }
+
+        const result = await client.query({
+          query: gql`
+            ${TWO_FACTOR_STATUS}
+          `,
+          fetchPolicy: "network-only",
+        });
+
+        this.status = result?.data?.twoFactorStatus ?? null;
+        if (!this.status) {
+          throw new Error(
+            "Não foi possível carregar as configurações de segurança.",
+          );
+        }
       } catch (error) {
+        this.status = null;
         this.errorMessage = this.getErrorMessage(
           error,
           "Não foi possível carregar as configurações de segurança.",
@@ -298,12 +346,22 @@ export default {
       this.passkeysLoading = true;
 
       try {
-        const query = gql`
-          ${PASSKEYS}
-        `;
-        const { data } = await useAsyncQuery(query, {});
-        this.passkeys = data.value?.passkeys ?? [];
+        const client = await this.waitForApolloClient();
+        if (!client) {
+          this.passkeys = [];
+          return;
+        }
+
+        const result = await client.query({
+          query: gql`
+            ${PASSKEYS}
+          `,
+          fetchPolicy: "network-only",
+        });
+
+        this.passkeys = result?.data?.passkeys ?? [];
       } catch (error) {
+        this.passkeys = [];
         this.errorMessage = this.getErrorMessage(
           error,
           "Não foi possível carregar as chaves de acesso.",
@@ -359,7 +417,9 @@ export default {
       );
     },
     async addPasskey() {
+      this.refreshPasskeySupport();
       if (!this.passkeysSupported) {
+        this.errorMessage = this.passkeyUnsupportedMessage;
         return;
       }
 
@@ -367,17 +427,17 @@ export default {
       this.errorMessage = "";
 
       try {
-        const beginMutation = gql`
-          ${BEGIN_PASSKEY_REGISTRATION}
-        `;
-        const { mutate: beginMutate } = await useMutation(beginMutation, {
-          variables: {},
-        });
-        const { data: beginData } = await beginMutate();
-        const begin = beginData?.beginPasskeyRegistration;
+        const begin = await this.runMutation(
+          BEGIN_PASSKEY_REGISTRATION,
+          {},
+          (data) => data?.beginPasskeyRegistration ?? null,
+        );
 
         if (!begin?.optionsJson || !begin?.registrationId) {
-          throw new Error("Não foi possível iniciar o registro da passkey.");
+          if (!this.errorMessage) {
+            throw new Error("Não foi possível iniciar o registro da passkey.");
+          }
+          return;
         }
 
         const credential = await createPasskeyCredential(begin.optionsJson);
@@ -470,23 +530,36 @@ export default {
       this.errorMessage = "";
 
       try {
-        const mutation = gql`
-          ${document}
-        `;
-        const { mutate } = await useMutation(mutation, { variables });
-        const { data } = await mutate();
-        onSuccess(data);
+        const client = await this.waitForApolloClient();
+        if (!client) {
+          throw new Error("Cliente GraphQL indisponível. Recarregue a página.");
+        }
+
+        const result = await client.mutate({
+          mutation: gql`
+            ${document}
+          `,
+          variables,
+        });
+
+        return onSuccess(result?.data);
       } catch (error) {
         this.errorMessage = this.getErrorMessage(
           error,
           "Não foi possível concluir esta ação. Tente novamente.",
         );
+        return null;
       } finally {
         this.busy = false;
       }
     },
     getErrorMessage(error, fallback) {
-      return error.graphQLErrors?.[0]?.message || error.message || fallback;
+      return (
+        error.graphQLErrors?.[0]?.message ||
+        error.networkError?.result?.errors?.[0]?.message ||
+        error.message ||
+        fallback
+      );
     },
   },
 };
@@ -699,6 +772,12 @@ export default {
   margin: 12px 0 0;
   color: #6b7280;
   font-size: 13px;
+  line-height: 1.5;
+}
+
+.passkey-unsupported {
+  color: #92400e;
+  max-width: 42rem;
 }
 
 .passkey-list {
@@ -737,10 +816,18 @@ export default {
 }
 
 .status-unavailable {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
   padding: 16px;
   border-radius: 8px;
   color: #991b1b;
   background: #fef2f2;
+}
+
+.status-unavailable p {
+  margin: 0;
 }
 
 .action-buttons {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@simplewebauthn/browser':
+        specifier: ^13.3.0
+        version: 13.3.0
       '@stripe/stripe-js':
         specifier: ^2.4.0
         version: 2.4.0
@@ -1195,6 +1198,9 @@ packages:
     resolution: {integrity: sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==}
     cpu: [x64]
     os: [win32]
+
+  '@simplewebauthn/browser@13.3.0':
+    resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
 
   '@sindresorhus/base62@1.0.0':
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
@@ -5347,6 +5353,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.53.3':
     optional: true
+
+  '@simplewebauthn/browser@13.3.0': {}
 
   '@sindresorhus/base62@1.0.0': {}
 

--- a/utils/passkeys.js
+++ b/utils/passkeys.js
@@ -1,0 +1,38 @@
+import {
+  browserSupportsWebAuthn,
+  startAuthentication,
+  startRegistration,
+} from "@simplewebauthn/browser";
+
+export function supportsPasskeys() {
+  return browserSupportsWebAuthn();
+}
+
+export function parseWebAuthnOptions(optionsJson) {
+  if (typeof optionsJson !== "string" || optionsJson === "") {
+    throw new Error("Opções WebAuthn inválidas.");
+  }
+
+  const options = JSON.parse(optionsJson);
+  if (!options || typeof options !== "object") {
+    throw new Error("Opções WebAuthn inválidas.");
+  }
+
+  return options;
+}
+
+export async function createPasskeyCredential(optionsJson) {
+  return startRegistration({
+    optionsJSON: parseWebAuthnOptions(optionsJson),
+  });
+}
+
+export async function assertPasskeyCredential(optionsJson) {
+  return startAuthentication({
+    optionsJSON: parseWebAuthnOptions(optionsJson),
+  });
+}
+
+export function credentialToJson(credential) {
+  return JSON.stringify(credential);
+}

--- a/utils/passkeys.js
+++ b/utils/passkeys.js
@@ -4,8 +4,59 @@ import {
   startRegistration,
 } from "@simplewebauthn/browser";
 
+export function isSecurePasskeyContext() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return window.isSecureContext === true;
+}
+
 export function supportsPasskeys() {
-  return browserSupportsWebAuthn();
+  return isSecurePasskeyContext() && browserSupportsWebAuthn();
+}
+
+export function isLocalInsecureOrigin() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  if (window.isSecureContext) {
+    return false;
+  }
+
+  const host = window.location.hostname;
+  return (
+    host === "localhost" ||
+    host.endsWith(".local") ||
+    host.endsWith(".test") ||
+    host.endsWith(".localhost")
+  );
+}
+
+export function passkeySupportMessage() {
+  if (typeof window === "undefined") {
+    return "Chaves de acesso indisponíveis neste ambiente.";
+  }
+
+  if (!isSecurePasskeyContext()) {
+    if (isLocalInsecureOrigin()) {
+      return [
+        "Chaves de acesso exigem contexto seguro. No Chrome local:",
+        "1) Abra chrome://flags/#unsafely-treat-insecure-origin-as-secure",
+        `2) Adicione ${window.location.origin}`,
+        "3) Clique em Relaunch e recarregue esta página",
+      ].join(" ");
+    }
+
+    return "Chaves de acesso só funcionam em conexões seguras (HTTPS).";
+  }
+
+  if (!browserSupportsWebAuthn()) {
+    return "Este navegador não oferece chaves de acesso.";
+  }
+
+  return "";
 }
 
 export function parseWebAuthnOptions(optionsJson) {


### PR DESCRIPTION
### Jira

[VT-134](https://zorensoftware.atlassian.net/browse/VT-134)

### O que?
Adiciona autenticação em duas etapas no front: challenge no login (TOTP/recovery/passkey), página `/settings/security` para gerenciar TOTP e passkeys, e aviso sutil no layout quando 2FA ainda não está ativo.

### Por quê?
Permitir que o usuário ative segurança extra (VT-134), alinhado à mesma experiência do Marketing Hub.

### Como?
- Challenge no `ZLoginForm` após login com 2FA habilitado
- GraphQL docs para enable/confirm/disable TOTP, challenge e passkeys
- `@simplewebauthn/browser` + `utils/passkeys.js` para WebAuthn
- Banner no `layouts/default.vue` apontando para `/settings/security`

### Capturas de tela
N/A nesta abertura (draft — validar visualmente antes do ready for review).

### Verificações
- [ ] Lembrete: Ajustar o `composer.json` com a versão.

### Test plan
- [ ] Login sem 2FA segue normal
- [ ] Login com TOTP abre challenge e autentica com código/recovery
- [ ] Login com passkey no challenge
- [ ] Ativar/desativar TOTP em `/settings/security`
- [ ] Registrar/remover passkey
- [ ] Banner some quando algum método 2FA está ativo


Made with [Cursor](https://cursor.com)

[VT-134]: https://zorensoftware.atlassian.net/browse/VT-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ